### PR TITLE
Fix BLE config-flow robustness, enable Time Sync button, and improve scan-retry UX

### DIFF
--- a/custom_components/scent_assistant/__init__.py
+++ b/custom_components/scent_assistant/__init__.py
@@ -29,7 +29,7 @@ from .protocol_cloud import AromaLinkCloudClient
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = ["switch", "sensor", "number", "time"]
+PLATFORMS = ["switch", "sensor", "number", "time", "button"]
 
 SERVICE_SET_SCHEDULE = "set_schedule"
 

--- a/custom_components/scent_assistant/config_flow.py
+++ b/custom_components/scent_assistant/config_flow.py
@@ -19,6 +19,7 @@ from .const import (
     CONF_CLOUD_USER_ID,
     CONF_CONNECTION_MODE,
     DEFAULT_SCAN_TIMEOUT,
+    DeviceType,
 )
 from .protocol_ble import detect_device_type
 from .protocol_cloud import AromaLinkCloudClient
@@ -59,7 +60,13 @@ class ScentDiffuserConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
 
         if user_input is not None:
-            address = user_input["ble_address"]
+            address = user_input.get("ble_address")
+            if not address:
+                return self.async_show_form(
+                    step_id="ble_scan",
+                    data_schema=vol.Schema({}),
+                    errors={"base": "cannot_connect"},
+                )
             device_info = self._discovered_devices.get(address, {})
             self._selected_ble_address = address
             self._selected_ble_name = device_info.get("name", "")

--- a/custom_components/scent_assistant/config_flow.py
+++ b/custom_components/scent_assistant/config_flow.py
@@ -61,31 +61,29 @@ class ScentDiffuserConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             address = user_input.get("ble_address")
-            if not address:
-                return self.async_show_form(
-                    step_id="ble_scan",
-                    data_schema=vol.Schema({}),
-                    errors={"base": "cannot_connect"},
+            if address:
+                # User selected a device – proceed to create entry
+                device_info = self._discovered_devices.get(address, {})
+                self._selected_ble_address = address
+                self._selected_ble_name = device_info.get("name", "")
+                self._selected_device_type = device_info.get("device_type", "aroma_link")
+
+                # Check if already configured
+                await self.async_set_unique_id(address)
+                self._abort_if_unique_id_configured()
+
+                # Create entry directly - no extra steps needed for BLE
+                return self.async_create_entry(
+                    title=self._selected_ble_name or "Scent Diffuser",
+                    data={
+                        CONF_BLE_ADDRESS: self._selected_ble_address,
+                        CONF_BLE_NAME: self._selected_ble_name,
+                        CONF_DEVICE_TYPE: self._selected_device_type,
+                        CONF_CONNECTION_MODE: "ble",
+                    },
                 )
-            device_info = self._discovered_devices.get(address, {})
-            self._selected_ble_address = address
-            self._selected_ble_name = device_info.get("name", "")
-            self._selected_device_type = device_info.get("device_type", "aroma_link")
-
-            # Check if already configured
-            await self.async_set_unique_id(address)
-            self._abort_if_unique_id_configured()
-
-            # Create entry directly - no extra steps needed for BLE
-            return self.async_create_entry(
-                title=self._selected_ble_name or "Scent Diffuser",
-                data={
-                    CONF_BLE_ADDRESS: self._selected_ble_address,
-                    CONF_BLE_NAME: self._selected_ble_name,
-                    CONF_DEVICE_TYPE: self._selected_device_type,
-                    CONF_CONNECTION_MODE: "ble",
-                },
-            )
+            # If address is missing, user clicked Submit on an empty error
+            # form – fall through to re-scan.
 
         # Scan for devices
         self._discovered_devices = {}

--- a/custom_components/scent_assistant/device.py
+++ b/custom_components/scent_assistant/device.py
@@ -384,6 +384,13 @@ class ScentDiffuserDevice:
                     self._state.phase = status["phase"]
                 self._notify_state_changed()
 
+    async def sync_time(self) -> bool:
+        """Sync device clock to current local time (BLE only)."""
+        if not self._ble_address:
+            return False
+        self._ble_has_synced_time = False
+        return await self._ble_connect()
+
     # ------------------------------------------------------------------
     # Startup / Shutdown
     # ------------------------------------------------------------------


### PR DESCRIPTION
Closes #2

This PR fixes the Bluetooth setup flow crashes reported in #2 (`NameError: name 'DeviceType' is not defined` and `KeyError: 'ble_address'`), and ensures the Time Sync button entity actually loads.

The implementation follows the approach proposed by @QbitPrime in the issue.

### Changes

| File | What changed | Why |
|---|---|---|
| `custom_components/scent_assistant/config_flow.py` | – Imports missing `DeviceType` from `const.py`  <br>– Replaces unsafe `user_input["ble_address"]` with `.get()`  <br>– Adds validation when `ble_address` is missing  <br>– Falls through to re-scan instead of erroring when user clicks **Submit** without selecting a device | Fixes the `NameError` and `KeyError` that block BLE discovery. Also improves the retry UX: if the scan list is empty or the user hits Submit too quickly, the flow simply rescans instead of showing a bare error form. |
| `custom_components/scent_assistant/device.py` | Adds `sync_time()` method | `TimeSyncButton` entity calls this, but the method was missing, causing an `AttributeError` when the button was pressed. |
| `custom_components/scent_assistant/__init__.py` | Adds `"button"` to `PLATFORMS` | Ensures the Time Sync button platform is loaded at start-up. |

### Testing notes
* Run the Hassfest and HACS CI workflows already present in the repo to verify manifest/platform compliance.
* Add the integration via **BLE** and verify that:
  1. Submitting the form with no device selected triggers a fresh scan instead of a hard error.
  2. The **Time Sync** button entity appears under the device and can be pressed without an `AttributeError`.