### PR TITLE
Add experimental Scentiment Diffuser Air 2 BLE support

### DIFF
--- a/custom_components/scent_assistant/const.py
+++ b/custom_components/scent_assistant/const.py
@@ -10,6 +10,7 @@ DOMAIN = "scent_assistant"
 class DeviceType(StrEnum):
     TUYA_BLE = "tuya_ble"          # ShinePick QT-I300 and similar
     AROMA_LINK = "aroma_link"      # Aroma-Link WiFi+BLE diffusers
+    SCENTIMENT = "scentiment"      # Scentiment Diffuser Air 2 (BLE, JSON protocol)
 
 
 # ---------------------------------------------------------------------------
@@ -21,6 +22,12 @@ CHAR_WRITE_UUID = "0000fff2-0000-1000-8000-00805f9b34fb"
 CHAR_NOTIFY_UUID = "0000fff1-0000-1000-8000-00805f9b34fb"
 CHAR_INDICATE_UUID = "0000fff3-0000-1000-8000-00805f9b34fb"  # Aroma-Link only
 
+# Scentiment Diffuser Air 2 — custom 16-bit UUIDs in the SIG base
+SCENTIMENT_SERVICE_UUID = "00000180-0000-1000-8000-00805f9b34fb"
+SCENTIMENT_CHAR_WRITE_UUID = "0000dead-0000-1000-8000-00805f9b34fb"  # Commands (JSON)
+SCENTIMENT_CHAR_NOTIFY_UUID = "0000fef3-0000-1000-8000-00805f9b34fb"  # State notifications
+SCENTIMENT_CHAR_INFO_UUID = "0000fef4-0000-1000-8000-00805f9b34fb"   # Device metadata (read)
+
 # ---------------------------------------------------------------------------
 # BLE name patterns for device detection
 # ---------------------------------------------------------------------------
@@ -28,6 +35,7 @@ CHAR_INDICATE_UUID = "0000fff3-0000-1000-8000-00805f9b34fb"  # Aroma-Link only
 BLE_NAME_PATTERNS = {
     DeviceType.AROMA_LINK: ["Scent "],
     DeviceType.TUYA_BLE: ["BT-ivy"],
+    DeviceType.SCENTIMENT: ["SCENTI"],
 }
 
 # ---------------------------------------------------------------------------

--- a/custom_components/scent_assistant/device.py
+++ b/custom_components/scent_assistant/device.py
@@ -14,8 +14,6 @@ from bleak import BleakClient, BleakScanner, BleakError
 
 from .const import (
     DeviceType,
-    CHAR_WRITE_UUID,
-    CHAR_NOTIFY_UUID,
     DEFAULT_CONNECT_TIMEOUT,
     DEFAULT_WORK_DURATION,
     DEFAULT_PAUSE_DURATION,
@@ -160,15 +158,22 @@ class ScentDiffuserDevice:
 
                 # Subscribe to notifications for responses
                 try:
-                    await self._ble_client.start_notify(CHAR_NOTIFY_UUID, self._on_ble_notification)
+                    await self._ble_client.start_notify(
+                        self._protocol.notify_char_uuid, self._on_ble_notification
+                    )
                 except Exception:
                     _LOGGER.debug("Could not subscribe to notifications")
 
-                # Time sync on first connection of this session
+                # Time sync on first connection of this session (skipped for
+                # protocols that don't support it).
                 if not self._ble_has_synced_time:
-                    await self._ble_send(self._protocol.build_time_sync())
+                    time_sync = self._protocol.build_time_sync()
+                    if time_sync:
+                        await self._ble_send(time_sync)
+                        _LOGGER.info("BLE connected + time synced: %s", self._ble_name)
+                    else:
+                        _LOGGER.info("BLE connected: %s", self._ble_name)
                     self._ble_has_synced_time = True
-                    _LOGGER.info("BLE connected + time synced: %s", self._ble_name)
 
                 self._schedule_disconnect()
                 return True
@@ -202,7 +207,9 @@ class ScentDiffuserDevice:
         if not self._ble_client or not self._ble_client.is_connected:
             return False
         try:
-            await self._ble_client.write_gatt_char(CHAR_WRITE_UUID, data, response=True)
+            await self._ble_client.write_gatt_char(
+                self._protocol.write_char_uuid, data, response=True
+            )
             return True
         except (BleakError, asyncio.TimeoutError, OSError) as err:
             _LOGGER.warning("BLE write failed: %s", err)

--- a/custom_components/scent_assistant/manifest.json
+++ b/custom_components/scent_assistant/manifest.json
@@ -3,7 +3,8 @@
   "name": "Scent Assistant",
   "bluetooth": [
     { "local_name": "Scent *" },
-    { "local_name": "BT-ivy*" }
+    { "local_name": "BT-ivy*" },
+    { "local_name": "SCENTI*" }
   ],
   "codeowners": ["@mr-sparks"],
   "config_flow": true,
@@ -12,5 +13,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mr-sparks/scent-assistant/issues",
   "requirements": ["bleak>=0.21.0"],
-  "version": "1.0.2"
+  "version": "1.1.0-beta.1"
 }

--- a/custom_components/scent_assistant/protocol_ble.py
+++ b/custom_components/scent_assistant/protocol_ble.py
@@ -8,6 +8,8 @@ from dataclasses import dataclass, field
 
 from .const import (
     DeviceType,
+    SERVICE_UUID, CHAR_WRITE_UUID, CHAR_NOTIFY_UUID,
+    SCENTIMENT_SERVICE_UUID, SCENTIMENT_CHAR_WRITE_UUID, SCENTIMENT_CHAR_NOTIFY_UUID,
     TUYA_HEADER, TUYA_VERSION,
     TUYA_CMD_DP_WRITE, TUYA_CMD_DP_REPORT, TUYA_CMD_QUERY, TUYA_CMD_TIME_SYNC,
     TUYA_DP_TYPE_BOOL, TUYA_DP_TYPE_RAW,
@@ -20,6 +22,8 @@ from .const import (
     AL_SLOT_ENABLED, AL_SLOT_DISABLED,
     AL_PHASE_IDLE, AL_PHASE_SPRAYING, AL_PHASE_PAUSED,
 )
+
+import json
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -81,13 +85,19 @@ class BleProtocol(ABC):
 
     device_type: DeviceType
 
+    # Per-protocol BLE characteristic UUIDs (defaults to FFF0 family used by
+    # Tuya BLE and Aroma-Link). Override for devices with different GATT layout.
+    service_uuid: str = SERVICE_UUID
+    write_char_uuid: str = CHAR_WRITE_UUID
+    notify_char_uuid: str = CHAR_NOTIFY_UUID
+
     @abstractmethod
     def build_power(self, on: bool) -> bytes:
         """Build power on/off command."""
 
-    @abstractmethod
-    def build_time_sync(self, now: datetime | None = None) -> bytes:
-        """Build time synchronisation command."""
+    def build_time_sync(self, now: datetime | None = None) -> bytes | None:
+        """Build time synchronisation command. Return None if not supported."""
+        return None
 
     @abstractmethod
     def build_query(self) -> bytes:
@@ -350,6 +360,67 @@ class AromaLinkBleProtocol(BleProtocol):
 
 
 # ---------------------------------------------------------------------------
+# Scentiment Diffuser Air 2 — JSON-over-BLE
+# ---------------------------------------------------------------------------
+
+class ScentimentProtocol(BleProtocol):
+    """Scentiment Diffuser Air 2 — JSON commands on 0xDEAD, text status on 0xFEF3."""
+
+    device_type = DeviceType.SCENTIMENT
+    service_uuid = SCENTIMENT_SERVICE_UUID
+    write_char_uuid = SCENTIMENT_CHAR_WRITE_UUID
+    notify_char_uuid = SCENTIMENT_CHAR_NOTIFY_UUID
+
+    @staticmethod
+    def _encode(action: str, payload: dict) -> bytes:
+        return json.dumps({"action": action, "payload": payload}, separators=(",", ":")).encode("utf-8")
+
+    def build_power(self, on: bool) -> bytes:
+        return self._encode("TURN_ON", {"on": 1 if on else 0})
+
+    def build_set_level(self, level: int) -> bytes:
+        return self._encode("SET LEVEL", {"intensity": int(level)})
+
+    def build_query(self) -> bytes:
+        return b""
+
+    def parse_notification(self, data: bytes) -> dict:
+        try:
+            text = data.decode("utf-8", errors="replace").strip()
+        except Exception:
+            return {}
+
+        result: dict = {}
+        if text.startswith("{"):
+            try:
+                parsed = json.loads(text)
+                if isinstance(parsed, dict):
+                    result.update(parsed)
+            except Exception:
+                _LOGGER.debug("Scentiment: unparseable JSON notification: %r", text)
+            return result
+
+        if ":" in text:
+            key, _, value = text.partition(":")
+            key = key.strip().lower()
+            value = value.strip()
+            if key == "level":
+                try:
+                    lvl = int(value)
+                    result["level"] = lvl
+                    result["power"] = lvl > 0
+                    result["phase"] = "spraying" if lvl > 0 else "off"
+                except ValueError:
+                    pass
+            else:
+                result[key] = value
+        else:
+            _LOGGER.debug("Scentiment: unrecognised notification: %r", text)
+
+        return result
+
+
+# ---------------------------------------------------------------------------
 # Factory
 # ---------------------------------------------------------------------------
 
@@ -359,6 +430,8 @@ def get_protocol(device_type: DeviceType) -> BleProtocol:
         return TuyaBleProtocol()
     elif device_type == DeviceType.AROMA_LINK:
         return AromaLinkBleProtocol()
+    elif device_type == DeviceType.SCENTIMENT:
+        return ScentimentProtocol()
     raise ValueError(f"Unknown device type: {device_type}")
 
 
@@ -369,6 +442,7 @@ def detect_device_type(ble_name: str) -> DeviceType | None:
     for dtype, patterns in {
         DeviceType.AROMA_LINK: ["Scent "],
         DeviceType.TUYA_BLE: ["BT-ivy"],
+        DeviceType.SCENTIMENT: ["SCENTI"],
     }.items():
         for pattern in patterns:
             if ble_name.startswith(pattern):


### PR DESCRIPTION
Closes part of #7 (power on/off + state read; schedule still to come).

## What this adds

Experimental support for the **Scentiment Diffuser Air 2** based on the GATT dump and JSON command examples shared by @Redspray00 in #7. The device speaks a JSON-over-BLE protocol on a custom service:

| UUID | Direction | Role |
|---|---|---|
| `0x0180` | service | Custom primary service |
| `0xDEAD` | write | Commands (JSON) |
| `0xFEF3` | notify, read | State (text, e.g. `level:3`) |

The integration now:

- Auto-detects devices advertising a name starting with `SCENTI`
- Sends `{"action":"TURN_ON","payload":{"on":1\|0}}` on power changes
- Subscribes to `0xFEF3` and parses `level:N` / JSON status updates into HA state
- Exposes per-protocol GATT UUIDs so the existing FFF0-based devices (Aroma-Link, Tuya) are untouched

## Out of scope for this beta

- **Schedule writes** — the API name and payload shape aren't known yet; needs a btsnoop capture
- **Intensity (SET LEVEL) entity** — encoder is in place (`build_set_level`) but no number/select entity is wired up yet
- **Time sync** — the device doesn't appear to support it; `build_time_sync` is now optional at the protocol level

## Risk assessment

The refactor of write/notify UUIDs from module-level constants onto the protocol class is the only thing that touches existing devices. The Tuya and Aroma-Link handlers inherit the previous default UUIDs unchanged, so behaviour for FFF0-based devices should be identical. Time sync still runs for protocols that implement it.

## Test plan

- Released as `v1.1.0-beta.1` (pre-release) so HACS beta channel users can opt in
- Asked @Redspray00 in #7 to test and report
- If confirmed working: promote to `v1.1.0` stable
- Follow-up release with schedule support once a btsnoop capture is provided