### PR TITLE
Add periodic cloud state polling + fix status endpoint URL

### DIFF
--- a/custom_components/scent_assistant/__init__.py
+++ b/custom_components/scent_assistant/__init__.py
@@ -2,12 +2,14 @@
 from __future__ import annotations
 
 import logging
+from datetime import timedelta
 
 import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+from homeassistant.helpers.event import async_track_time_interval
 import homeassistant.helpers.config_validation as cv
 
 from .const import (
@@ -19,6 +21,7 @@ from .const import (
     CONF_CLOUD_PASSWORD,
     CONF_CLOUD_DEVICE_ID,
     CONF_CONNECTION_MODE,
+    CLOUD_POLL_INTERVAL_SECONDS,
     WEEKDAY_MON, WEEKDAY_TUE, WEEKDAY_WED, WEEKDAY_THU,
     WEEKDAY_FRI, WEEKDAY_SAT, WEEKDAY_SUN,
     DeviceType,
@@ -101,6 +104,23 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     hass.data[DOMAIN][entry.entry_id] = device
 
+    # Cloud-mode devices have no push channel for autonomous state changes
+    # (BLE devices push notifications when connected). Poll the cloud
+    # periodically so HA reflects the device's real state, not just the
+    # last command we sent. See CLOUD_POLL_INTERVAL_SECONDS in const.py.
+    if connection_mode == "cloud" and cloud_client is not None:
+        async def _periodic_cloud_poll(now=None) -> None:
+            try:
+                await device.refresh_state()
+            except Exception as err:
+                _LOGGER.debug("Cloud state poll failed (will retry): %s", err)
+
+        device._unsub_cloud_poll = async_track_time_interval(
+            hass,
+            _periodic_cloud_poll,
+            timedelta(seconds=CLOUD_POLL_INTERVAL_SECONDS),
+        )
+
     # Register services (once for all entries)
     if not hass.services.has_service(DOMAIN, SERVICE_SET_SCHEDULE):
         async def handle_set_schedule(call: ServiceCall) -> None:
@@ -165,6 +185,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     if unload_ok:
         device: ScentDiffuserDevice = hass.data[DOMAIN].pop(entry.entry_id)
+        unsub = getattr(device, "_unsub_cloud_poll", None)
+        if unsub is not None:
+            unsub()
         await device.async_shutdown()
 
     return unload_ok

--- a/custom_components/scent_assistant/const.py
+++ b/custom_components/scent_assistant/const.py
@@ -99,8 +99,14 @@ CLOUD_WEB_URL = "https://www.aroma-link.com"
 CLOUD_ENDPOINT_TOKEN = "/v2/app/token"
 CLOUD_ENDPOINT_DEVICES = "/v1/app/device/listAll/{user_id}"
 CLOUD_ENDPOINT_SWITCH = "/v1/app/data/newSwitch"
-CLOUD_ENDPOINT_STATUS = "/v1/app/device/newWork/{device_id}"
+CLOUD_ENDPOINT_STATUS = "/v1/app/device/work/{device_id}"
 CLOUD_ENDPOINT_SCHEDULE = "/v1/app/data/workSetApp"
+
+# Polling interval for cloud-mode devices. The integration previously had no
+# periodic refresh, so HA never observed autonomous spray cycles between
+# user-initiated commands. The Aroma-Link cloud exposes near-real-time state
+# (onOff, workStatus, work/pauseRemainTime, pumpCount) via /v1/app/device/work/{id}.
+CLOUD_POLL_INTERVAL_SECONDS = 60
 
 # ---------------------------------------------------------------------------
 # Weekday bitmask (shared by both protocols)


### PR DESCRIPTION
## Problem

For cloud-mode (Aroma-Link) devices, `refresh_state()` is called exactly **once** at `async_setup_entry` and never again. There is no `DataUpdateCoordinator`, no `async_track_time_interval`, no `SCAN_INTERVAL`, and the cloud client has no push channel. As a result, HA's view of the device state is permanently frozen at "whatever the last HA-issued command implied" — even while the device runs its internal 24/7 schedule and sprays autonomously.

This shows up in the wild as: a user wakes up at 5am, finds the diffuser spraying, but HA shows `switch.diffuser_*_power = off`. Calling `switch.turn_off` is then a no-op because HA's cached state already says off, so the device keeps running.

## Diagnosis

Two things needed fixing:

### 1. `CLOUD_ENDPOINT_STATUS` URL is wrong

```python
# const.py — current:
CLOUD_ENDPOINT_STATUS = "/v1/app/device/newWork/{device_id}"
```

I verified against the live `aroma-link.com` API: this endpoint returns `{"code": 200, "msg": "OK"}` with **no `data` payload**, so `_parse_status` always returns `None` and `refresh_state()` is a no-op for cloud devices even if you do call it.

The endpoint that actually returns the snapshot is:

```
GET /v1/app/device/work/{device_id}?userId={user_id}
```

…which returns the full structure `_parse_status` already expects:

```json
{
  "onOff": 0|1,
  "workStatus": 0|1|2,      // 0=idle, 1=spraying, 2=paused
  "workRemainTime": <sec>,
  "pauseRemainTime": <sec>,
  "pumpCount": <int>,
  "runCount": <int>,
  "lastOnlineTime": <epoch>,
  ...
}
```

Manual verification: while `onOff=1`, `pauseRemainTime` decrements ~1s/sec — so this endpoint really does expose near-real-time state.

### 2. No periodic polling

Added `async_track_time_interval` in `async_setup_entry` for cloud-mode entries, calling `device.refresh_state()` every `CLOUD_POLL_INTERVAL_SECONDS` (default 60s). Existing `_notify_state_changed()` inside `refresh_state` already wakes the entities, so no entity changes needed.

BLE-mode entries are explicitly skipped — they have notifications over GATT and don't need polling.

Cleanup wired into `async_unload_entry` via a `_unsub_cloud_poll` attribute on the device.

## Changes

- `const.py`: fix endpoint URL; add `CLOUD_POLL_INTERVAL_SECONDS = 60`
- `__init__.py`: schedule periodic `refresh_state()` for cloud devices; unsubscribe on unload

## Tradeoffs

- One HTTPS request per cloud device per minute (~1440/day across all devices for a 3-diffuser setup). Acceptable given the integration already keeps a long-lived `access_token` from login.
- 60s is a conservative default; users with multiple cloud devices and rate-limit concerns can tune via the constant. Could be made configurable via an options flow in a follow-up.
- Polling adds load to `aroma-link.com`; if abusive, the cloud will start rejecting. Empirically tested without issues.

## How to verify

After installing this branch:
1. Configure a cloud-mode (Aroma-Link) device
2. Turn the device on via HA → spray cycle starts
3. Wait ≥60s — HA sensors (`sensor.*_status`) should now reflect `spraying` / `paused` as the device cycles, without any user action
4. Use the device's own buttons / cloud schedule to spray autonomously → within 60s, HA's `switch.*_power` flips to `on` on its own (matching reality)
