### PR TITLE
Complete Scentiment Diffuser Air 2 BLE protocol

### DIFF
--- a/custom_components/scent_assistant/__init__.py
+++ b/custom_components/scent_assistant/__init__.py
@@ -29,7 +29,7 @@ from .protocol_cloud import AromaLinkCloudClient
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS = ["switch", "sensor", "number", "time", "button"]
+PLATFORMS = ["switch", "sensor", "number", "time", "button", "light"]
 
 SERVICE_SET_SCHEDULE = "set_schedule"
 

--- a/custom_components/scent_assistant/button.py
+++ b/custom_components/scent_assistant/button.py
@@ -8,7 +8,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
+from .const import DOMAIN, DeviceType
 from .device import ScentDiffuserDevice
 
 _LOGGER = logging.getLogger(__name__)
@@ -21,6 +21,8 @@ async def async_setup_entry(
 ) -> None:
     """Set up button entities."""
     device: ScentDiffuserDevice = hass.data[DOMAIN][entry.entry_id]
+    if device.device_type == DeviceType.SCENTIMENT:
+        return
 
     async_add_entities([
         TimeSyncButton(device, entry),

--- a/custom_components/scent_assistant/device.py
+++ b/custom_components/scent_assistant/device.py
@@ -24,6 +24,7 @@ from .protocol_ble import (
     ScheduleSlot,
     ScheduleSetup,
     AromaLinkBleProtocol,
+    ScentimentProtocol,
     get_protocol,
     detect_device_type,
 )
@@ -254,6 +255,18 @@ class ScentDiffuserDevice:
             self._state.end_hour = updates["end_hour"]
             self._state.end_minute = updates.get("end_minute", 59)
             changed = True
+        if "level" in updates:
+            self._state.level = updates["level"]
+            changed = True
+        if "battery" in updates:
+            self._state.battery = updates["battery"]
+            changed = True
+        if "rgb_on" in updates:
+            self._state.rgb_on = updates["rgb_on"]
+            changed = True
+        if "rgb_color" in updates:
+            self._state.rgb_color = updates["rgb_color"]
+            changed = True
 
         if changed:
             self._notify_state_changed()
@@ -295,6 +308,39 @@ class ScentDiffuserDevice:
                 self._state.fan = on
                 self._notify_state_changed()
                 return True
+        return False
+
+    async def set_level(self, level: int) -> bool:
+        """Set Scentiment spray intensity (1-3)."""
+        if not isinstance(self._protocol, ScentimentProtocol) or not self._ble_address:
+            return False
+        cmd = self._protocol.build_set_level(level)
+        if await self._ble_execute(cmd):
+            self._state.level = level
+            self._notify_state_changed()
+            return True
+        return False
+
+    async def set_rgb_color(self, r: int, g: int, b: int) -> bool:
+        """Set Scentiment RGB LED color."""
+        if not isinstance(self._protocol, ScentimentProtocol) or not self._ble_address:
+            return False
+        cmd = self._protocol.build_set_rgb_color(r, g, b)
+        if await self._ble_execute(cmd):
+            self._state.rgb_color = (r, g, b)
+            self._notify_state_changed()
+            return True
+        return False
+
+    async def set_rgb_led(self, on: bool) -> bool:
+        """Turn Scentiment RGB LED on or off."""
+        if not isinstance(self._protocol, ScentimentProtocol) or not self._ble_address:
+            return False
+        cmd = self._protocol.build_set_rgb_led(on)
+        if await self._ble_execute(cmd):
+            self._state.rgb_on = on
+            self._notify_state_changed()
+            return True
         return False
 
     async def set_work_duration(self, seconds: int) -> bool:

--- a/custom_components/scent_assistant/light.py
+++ b/custom_components/scent_assistant/light.py
@@ -1,0 +1,75 @@
+"""Light entities for Scent Diffuser (Scentiment RGB only)."""
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.light import (
+    ATTR_RGB_COLOR,
+    ColorMode,
+    LightEntity,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN, DeviceType
+from .device import ScentDiffuserDevice
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up light entities (Scentiment only)."""
+    device: ScentDiffuserDevice = hass.data[DOMAIN][entry.entry_id]
+    if device.device_type != DeviceType.SCENTIMENT:
+        return
+    async_add_entities([ScentimentRgbLight(device, entry)])
+
+
+class ScentimentRgbLight(LightEntity):
+    """RGB LED on the Scentiment Diffuser Air 2."""
+
+    _attr_has_entity_name = True
+    _attr_name = "LED"
+    _attr_icon = "mdi:led-on"
+    _attr_color_mode = ColorMode.RGB
+    _attr_supported_color_modes = {ColorMode.RGB}
+
+    def __init__(self, device: ScentDiffuserDevice, entry: ConfigEntry) -> None:
+        self._device = device
+        self._attr_unique_id = f"{device.unique_id}_led"
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, device.unique_id)},
+        }
+        device.register_state_callback(self._on_state_update)
+
+    def _on_state_update(self) -> None:
+        if self.hass is None:
+            return
+        self.async_write_ha_state()
+
+    @property
+    def is_on(self) -> bool | None:
+        return self._device.state.rgb_on
+
+    @property
+    def rgb_color(self) -> tuple[int, int, int] | None:
+        return self._device.state.rgb_color
+
+    @property
+    def available(self) -> bool:
+        return self._device.available
+
+    async def async_turn_on(self, **kwargs) -> None:
+        rgb = kwargs.get(ATTR_RGB_COLOR)
+        if rgb is not None:
+            await self._device.set_rgb_color(rgb[0], rgb[1], rgb[2])
+        # Always make sure the LED itself is on after a color change.
+        await self._device.set_rgb_led(True)
+
+    async def async_turn_off(self, **kwargs) -> None:
+        await self._device.set_rgb_led(False)

--- a/custom_components/scent_assistant/manifest.json
+++ b/custom_components/scent_assistant/manifest.json
@@ -13,5 +13,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mr-sparks/scent-assistant/issues",
   "requirements": ["bleak>=0.21.0"],
-  "version": "1.1.0-beta.1"
+  "version": "1.1.0-beta.2"
 }

--- a/custom_components/scent_assistant/number.py
+++ b/custom_components/scent_assistant/number.py
@@ -8,7 +8,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
+from .const import DOMAIN, DeviceType
 from .device import ScentDiffuserDevice
 
 _LOGGER = logging.getLogger(__name__)
@@ -21,6 +21,10 @@ async def async_setup_entry(
 ) -> None:
     """Set up number entities."""
     device: ScentDiffuserDevice = hass.data[DOMAIN][entry.entry_id]
+
+    if device.device_type == DeviceType.SCENTIMENT:
+        async_add_entities([ScentimentLevelNumber(device, entry)])
+        return
 
     async_add_entities([
         WorkDurationNumber(device, entry),
@@ -96,3 +100,39 @@ class PauseDurationNumber(NumberEntity):
 
     async def async_set_native_value(self, value: float) -> None:
         await self._device.set_pause_duration(int(value))
+
+
+class ScentimentLevelNumber(NumberEntity):
+    """Spray intensity level (Scentiment, 1-3)."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Level"
+    _attr_icon = "mdi:speedometer"
+    _attr_native_min_value = 1
+    _attr_native_max_value = 3
+    _attr_native_step = 1
+    _attr_mode = NumberMode.SLIDER
+
+    def __init__(self, device: ScentDiffuserDevice, entry: ConfigEntry) -> None:
+        self._device = device
+        self._attr_unique_id = f"{device.unique_id}_level"
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, device.unique_id)},
+        }
+        device.register_state_callback(self._on_state_update)
+
+    def _on_state_update(self) -> None:
+        if self.hass is None:
+            return
+        self.async_write_ha_state()
+
+    @property
+    def native_value(self) -> float | None:
+        return self._device.state.level
+
+    @property
+    def available(self) -> bool:
+        return self._device.available
+
+    async def async_set_native_value(self, value: float) -> None:
+        await self._device.set_level(int(value))

--- a/custom_components/scent_assistant/protocol_ble.py
+++ b/custom_components/scent_assistant/protocol_ble.py
@@ -41,6 +41,11 @@ class DiffuserState:
     phase: str = "unknown"             # "off", "idle", "spraying", "paused"
     work_seconds: int = 0
     pause_seconds: int = 0
+    # Scentiment-only
+    level: int | None = None           # spray intensity 1-3
+    battery: int | None = None         # battery percent
+    rgb_on: bool | None = None         # RGB LED on/off
+    rgb_color: tuple[int, int, int] | None = None  # (r, g, b) 0-255
     start_hour: int = 0
     start_minute: int = 0
     end_hour: int = 23
@@ -371,17 +376,33 @@ class ScentimentProtocol(BleProtocol):
     write_char_uuid = SCENTIMENT_CHAR_WRITE_UUID
     notify_char_uuid = SCENTIMENT_CHAR_NOTIFY_UUID
 
-    @staticmethod
-    def _encode(action: str, payload: dict) -> bytes:
-        return json.dumps({"action": action, "payload": payload}, separators=(",", ":")).encode("utf-8")
+    # The device requires every command to be terminated with these two bytes.
+    _TERMINATOR = b"-|"
+
+    @classmethod
+    def _encode(cls, action: str, payload: dict | None = None) -> bytes:
+        obj: dict = {"action": action}
+        if payload is not None:
+            obj["payload"] = payload
+        return json.dumps(obj, separators=(",", ":")).encode("utf-8") + cls._TERMINATOR
 
     def build_power(self, on: bool) -> bytes:
         return self._encode("TURN_ON", {"on": 1 if on else 0})
 
     def build_set_level(self, level: int) -> bytes:
-        return self._encode("SET LEVEL", {"intensity": int(level)})
+        return self._encode("SET_LEVEL", {"intensity": int(level)})
+
+    def build_set_rgb_color(self, r: int, g: int, b: int) -> bytes:
+        return self._encode("SET_RGB_LEVEL", {"red": int(r), "green": int(g), "blue": int(b)})
+
+    def build_set_rgb_led(self, on: bool) -> bytes:
+        return self._encode("SET_RGB_LED", {"on": 1 if on else 0})
+
+    def build_ping(self) -> bytes:
+        return self._encode("PING")
 
     def build_query(self) -> bytes:
+        # The device pushes state via notifications; no explicit query needed.
         return b""
 
     def parse_notification(self, data: bytes) -> dict:
@@ -390,7 +411,12 @@ class ScentimentProtocol(BleProtocol):
         except Exception:
             return {}
 
+        # Strip the trailing "-|" terminator if the device echoes it back.
+        if text.endswith("-|"):
+            text = text[:-2].strip()
+
         result: dict = {}
+
         if text.startswith("{"):
             try:
                 parsed = json.loads(text)
@@ -400,6 +426,28 @@ class ScentimentProtocol(BleProtocol):
                 _LOGGER.debug("Scentiment: unparseable JSON notification: %r", text)
             return result
 
+        # Comma-separated status: "S:1,L:3,C:1,Bat:100"
+        if "," in text and ":" in text:
+            for part in text.split(","):
+                key, _, value = part.partition(":")
+                key = key.strip().lower()
+                value = value.strip()
+                if not value:
+                    continue
+                try:
+                    n = int(value)
+                except ValueError:
+                    continue
+                if key == "s":
+                    result["power"] = n > 0
+                    result["phase"] = "spraying" if n > 0 else "off"
+                elif key == "l":
+                    result["level"] = n
+                elif key == "bat":
+                    result["battery"] = n
+            return result
+
+        # Single key:value notification
         if ":" in text:
             key, _, value = text.partition(":")
             key = key.strip().lower()
@@ -408,8 +456,15 @@ class ScentimentProtocol(BleProtocol):
                 try:
                     lvl = int(value)
                     result["level"] = lvl
-                    result["power"] = lvl > 0
-                    result["phase"] = "spraying" if lvl > 0 else "off"
+                    if lvl > 0:
+                        result["phase"] = "spraying"
+                except ValueError:
+                    pass
+            elif key == "enable":
+                try:
+                    en = int(value)
+                    result["power"] = en > 0
+                    result["phase"] = "spraying" if en > 0 else "off"
                 except ValueError:
                     pass
             else:

--- a/custom_components/scent_assistant/sensor.py
+++ b/custom_components/scent_assistant/sensor.py
@@ -3,12 +3,17 @@ from __future__ import annotations
 
 import logging
 
-from homeassistant.components.sensor import SensorEntity
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorStateClass,
+)
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import PERCENTAGE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
+from .const import DOMAIN, DeviceType
 from .device import ScentDiffuserDevice
 
 _LOGGER = logging.getLogger(__name__)
@@ -22,10 +27,14 @@ async def async_setup_entry(
     """Set up sensor entities."""
     device: ScentDiffuserDevice = hass.data[DOMAIN][entry.entry_id]
 
-    async_add_entities([
+    entities: list[SensorEntity] = [
         DiffuserStatusSensor(device, entry),
         DiffuserConnectionSensor(device, entry),
-    ])
+    ]
+    if device.device_type == DeviceType.SCENTIMENT:
+        entities.append(DiffuserBatterySensor(device, entry))
+
+    async_add_entities(entities)
 
 
 class DiffuserStatusSensor(SensorEntity):
@@ -55,6 +64,8 @@ class DiffuserStatusSensor(SensorEntity):
     @property
     def extra_state_attributes(self) -> dict:
         state = self._device.state
+        if self._device.device_type == DeviceType.SCENTIMENT:
+            return {"level": state.level}
         return {
             "work_seconds": state.work_seconds,
             "pause_seconds": state.pause_seconds,
@@ -65,6 +76,37 @@ class DiffuserStatusSensor(SensorEntity):
     @property
     def available(self) -> bool:
         return self._device.available
+
+
+class DiffuserBatterySensor(SensorEntity):
+    """Battery level (Scentiment only)."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Battery"
+    _attr_device_class = SensorDeviceClass.BATTERY
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_native_unit_of_measurement = PERCENTAGE
+
+    def __init__(self, device: ScentDiffuserDevice, entry: ConfigEntry) -> None:
+        self._device = device
+        self._attr_unique_id = f"{device.unique_id}_battery"
+        self._attr_device_info = {
+            "identifiers": {(DOMAIN, device.unique_id)},
+        }
+        device.register_state_callback(self._on_state_update)
+
+    def _on_state_update(self) -> None:
+        if self.hass is None:
+            return
+        self.async_write_ha_state()
+
+    @property
+    def native_value(self) -> int | None:
+        return self._device.state.battery
+
+    @property
+    def available(self) -> bool:
+        return self._device.available and self._device.state.battery is not None
 
 
 class DiffuserConnectionSensor(SensorEntity):

--- a/custom_components/scent_assistant/time.py
+++ b/custom_components/scent_assistant/time.py
@@ -9,7 +9,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
+from .const import DOMAIN, DeviceType
 from .device import ScentDiffuserDevice
 
 _LOGGER = logging.getLogger(__name__)
@@ -22,6 +22,8 @@ async def async_setup_entry(
 ) -> None:
     """Set up time entities."""
     device: ScentDiffuserDevice = hass.data[DOMAIN][entry.entry_id]
+    if device.device_type == DeviceType.SCENTIMENT:
+        return
 
     async_add_entities([
         DiffuserStartTime(device, entry),


### PR DESCRIPTION
Builds on #9. With the complete protocol now reverse-engineered from @Redspray00's btsnoop captures + nRF Connect hex in #7, this adds the full feature set for the Scentiment Diffuser Air 2.

## Changes

### Protocol (`protocol_ble.py`)
All commands now correctly terminated with `-|` (the previous beta-1 lacked this — devices would silently ignore the JSON):

| Action | Payload | Purpose |
|---|---|---|
| `TURN_ON` | `{"on": 0\|1}` | Power on/off |
| `SET_LEVEL` | `{"intensity": 1-3}` | Spray intensity |
| `SET_RGB_LEVEL` | `{red, green, blue}` | LED color (and warm/cool is just RGB) |
| `SET_RGB_LED` | `{"on": 0\|1}` | LED on/off |
| `PING` | — | Keepalive |

Notification parser now handles `enable:N`, `level:N`, `S:N,L:N,C:N,Bat:N`, JSON forms, and strips the `-|` if echoed.

### New entities for Scentiment

- **Power** switch (TURN_ON)
- **Level** number slider 1-3 (SET_LEVEL)
- **LED** light entity with RGB color (SET_RGB_LED + SET_RGB_LEVEL)
- **Battery** sensor (parsed from `Bat:N` in periodic status)

### Hidden for Scentiment

Aroma-Link / Tuya-only entities don't make sense here:
- Fan switch (already gated)
- Time Sync button
- Start/End Time entities
- Work/Pause Duration numbers

### Not implemented (intentionally)

**Schedule** — Daniel confirmed the schedule lives in the official app, not the device, so it cannot be controlled via BLE. HA users can replicate this with automations on top of the Power + Level entities.

## Risk

The only changes touching existing devices are the new optional `DiffuserState` fields (`level`, `battery`, `rgb_on`, `rgb_color`) and the new optional state-update keys in `_on_ble_notification`. Aroma-Link and Tuya handlers continue to use the FFF0 characteristic family and supply `build_time_sync()`, so behaviour for those devices is unchanged. Verified via smoke test:

```
aroma_link: write_uuid=0000fff2-... notify_uuid=0000fff1-...  time_sync supports: True
tuya_ble:   write_uuid=0000fff2-... notify_uuid=0000fff1-...  time_sync supports: True
```

## Test plan

Released as `v1.1.0-beta.2` (pre-release). @Redspray00 to test against actual hardware; if good, promote to `v1.1.0` stable without further code change.

Bytes verified to match Daniel's hex dump exactly for `TURN_ON` on/off.