### PR TITLE
Fix Scentiment BLE name detection (case-insensitive)

### DIFF
--- a/custom_components/scent_assistant/const.py
+++ b/custom_components/scent_assistant/const.py
@@ -35,7 +35,7 @@ SCENTIMENT_CHAR_INFO_UUID = "0000fef4-0000-1000-8000-00805f9b34fb"   # Device me
 BLE_NAME_PATTERNS = {
     DeviceType.AROMA_LINK: ["Scent "],
     DeviceType.TUYA_BLE: ["BT-ivy"],
-    DeviceType.SCENTIMENT: ["SCENTI"],
+    DeviceType.SCENTIMENT: ["Scentiment"],
 }
 
 # ---------------------------------------------------------------------------

--- a/custom_components/scent_assistant/manifest.json
+++ b/custom_components/scent_assistant/manifest.json
@@ -4,7 +4,7 @@
   "bluetooth": [
     { "local_name": "Scent *" },
     { "local_name": "BT-ivy*" },
-    { "local_name": "SCENTI*" }
+    { "local_name": "Scentiment*" }
   ],
   "codeowners": ["@mr-sparks"],
   "config_flow": true,
@@ -13,5 +13,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mr-sparks/scent-assistant/issues",
   "requirements": ["bleak>=0.21.0"],
-  "version": "1.1.0-beta.3"
+  "version": "1.1.0-beta.4"
 }

--- a/custom_components/scent_assistant/protocol_ble.py
+++ b/custom_components/scent_assistant/protocol_ble.py
@@ -491,15 +491,16 @@ def get_protocol(device_type: DeviceType) -> BleProtocol:
 
 
 def detect_device_type(ble_name: str) -> DeviceType | None:
-    """Detect device type from BLE advertisement name."""
+    """Detect device type from BLE advertisement name (case-insensitive)."""
     if not ble_name:
         return None
+    lowered = ble_name.lower()
     for dtype, patterns in {
         DeviceType.AROMA_LINK: ["Scent "],
         DeviceType.TUYA_BLE: ["BT-ivy"],
-        DeviceType.SCENTIMENT: ["SCENTI"],
+        DeviceType.SCENTIMENT: ["Scentiment"],
     }.items():
         for pattern in patterns:
-            if ble_name.startswith(pattern):
+            if lowered.startswith(pattern.lower()):
                 return dtype
     return None


### PR DESCRIPTION
Root cause for @Redspray00's "nothing changed" report in #7.

The device's actual advertised name is `Scentiment-W W n 8CBFEA39C99C` (CamelCase), but the detection prefix was `SCENTI` (all caps). Since `"Scentiment-...".startswith("SCENTI")` is `False`, `detect_device_type` returned `None`, and the [config_flow fallback](https://github.com/mr-sparks/scent-assistant/blob/main/custom_components/scent_assistant/config_flow.py#L103) assigned `DeviceType.AROMA_LINK`. The Aroma-Link binary protocol then attempted to write to the FFF2 characteristic, which doesn't exist on this device — explaining why the device looked unresponsive even though the JSON protocol bytes are correct (Daniel verified those work via nRF Connect).

## Fix

- Pattern `SCENTI` → `Scentiment` in `const.py` and `protocol_ble.py`
- `detect_device_type` now matches case-insensitively, so future firmware revisions advertising as `SCENTIMENT_...` or `scentiment-...` would also be handled
- `manifest.json` bluetooth discovery pattern updated to `Scentiment*`

Smoke-tested against the actual device name plus a few capitalisation variants:

```
'Scentiment-W W n 8CBFEA39C99C'  -> scentiment
'SCENTIMENT_39C99C'              -> scentiment
'scentiment'                     -> scentiment
'Scent Diffuser'                 -> aroma_link  (unchanged)
'BT-ivy-123'                     -> tuya_ble    (unchanged)
'Random Device'                  -> None
```

## User-side action required

Daniel (and anyone else who installed beta.1/2/3 with a Scentiment device) needs to **delete the integration via Settings → Devices & Services → ⋮ → Delete and re-add via Bluetooth**. The stored config entry has `device_type: aroma_link` cached and won't update on a code-only upgrade. Skipping a migration on purpose — beta context, only known user is the issue reporter, and the migration would be incomplete (old Aroma-Link entity registry entries would linger).

Bump to `1.1.0-beta.4`.