### PR TITLE
Add Scent Marketing device family support (AK + GW + GW-XOR + Tuya PID-98)

### DIFF
--- a/custom_components/scent_assistant/__init__.py
+++ b/custom_components/scent_assistant/__init__.py
@@ -94,6 +94,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         device_type=device_type,
         cloud_client=cloud_client,
         cloud_device_id=cloud_device_id,
+        sm_metadata=entry.data.get("sm_metadata"),
+        gw_password=entry.data.get("gw_password"),
     )
 
     # Initial state query (BLE: connects briefly then disconnects; Cloud: polls API)

--- a/custom_components/scent_assistant/config_flow.py
+++ b/custom_components/scent_assistant/config_flow.py
@@ -18,10 +18,11 @@ from .const import (
     CONF_CLOUD_DEVICE_ID,
     CONF_CLOUD_USER_ID,
     CONF_CONNECTION_MODE,
+    CONF_GW_PASSWORD,
     DEFAULT_SCAN_TIMEOUT,
     DeviceType,
 )
-from .protocol_ble import detect_device_type
+from .protocol_ble import detect_device_type, extract_scent_marketing_metadata
 from .protocol_cloud import AromaLinkCloudClient
 
 _LOGGER = logging.getLogger(__name__)
@@ -39,6 +40,42 @@ class ScentDiffuserConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._selected_ble_address: str | None = None
         self._selected_ble_name: str | None = None
         self._selected_device_type: str | None = None
+        self._selected_sm_metadata: dict | None = None
+        self._selected_gw_password: str | None = None
+
+    def _create_ble_entry(self) -> config_entries.ConfigFlowResult:
+        """Build the BLE-mode config entry. Shared by all BLE setup paths."""
+        entry_data: dict[str, Any] = {
+            CONF_BLE_ADDRESS: self._selected_ble_address,
+            CONF_BLE_NAME: self._selected_ble_name,
+            CONF_DEVICE_TYPE: self._selected_device_type,
+            CONF_CONNECTION_MODE: "ble",
+        }
+        if self._selected_sm_metadata:
+            entry_data["sm_metadata"] = self._selected_sm_metadata
+        if self._selected_gw_password:
+            entry_data[CONF_GW_PASSWORD] = self._selected_gw_password
+        return self.async_create_entry(
+            title=self._selected_ble_name or "Scent Diffuser",
+            data=entry_data,
+        )
+
+    async def async_step_gw_password(
+        self, user_input: dict[str, Any] | None = None
+    ) -> config_entries.ConfigFlowResult:
+        """Optional password prompt for Scent Marketing GW devices."""
+        if user_input is not None:
+            pwd = (user_input.get(CONF_GW_PASSWORD) or "").strip()
+            # The firmware accepts up to 4 ASCII chars. We trim silently.
+            self._selected_gw_password = pwd[:4] if pwd else None
+            return self._create_ble_entry()
+        return self.async_show_form(
+            step_id="gw_password",
+            data_schema=vol.Schema({
+                vol.Optional(CONF_GW_PASSWORD, default=""): str,
+            }),
+            description_placeholders={"device": self._selected_ble_name or ""},
+        )
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
@@ -67,21 +104,22 @@ class ScentDiffuserConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 self._selected_ble_address = address
                 self._selected_ble_name = device_info.get("name", "")
                 self._selected_device_type = device_info.get("device_type", "aroma_link")
+                self._selected_sm_metadata = device_info.get("sm_metadata")
 
                 # Check if already configured
                 await self.async_set_unique_id(address)
                 self._abort_if_unique_id_configured()
 
-                # Create entry directly - no extra steps needed for BLE
-                return self.async_create_entry(
-                    title=self._selected_ble_name or "Scent Diffuser",
-                    data={
-                        CONF_BLE_ADDRESS: self._selected_ble_address,
-                        CONF_BLE_NAME: self._selected_ble_name,
-                        CONF_DEVICE_TYPE: self._selected_device_type,
-                        CONF_CONNECTION_MODE: "ble",
-                    },
-                )
+                # Scent Marketing GW devices may be password-protected.
+                # We can't tell at scan time, so offer the user a chance
+                # to supply one. AK devices have no such mechanism.
+                if self._selected_device_type in (
+                    DeviceType.SCENT_MARKETING_GW,
+                    DeviceType.SCENT_MARKETING_GW_XOR,
+                ):
+                    return await self.async_step_gw_password()
+
+                return self._create_ble_entry()
             # If address is missing, user clicked Submit on an empty error
             # form – fall through to re-scan.
 
@@ -91,18 +129,31 @@ class ScentDiffuserConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             devices = await BleakScanner.discover(timeout=DEFAULT_SCAN_TIMEOUT, return_adv=True)
             for device, adv_data in devices.values():
                 name = device.name or adv_data.local_name or ""
-                if not name:
+                dtype = detect_device_type(name, adv_data)
+
+                # A Scent Marketing device may advertise without a useful
+                # local name (the app routes purely on manufacturer-data),
+                # so we accept it even when `name` is empty.
+                if not name and dtype is None:
                     continue
+                if not name:
+                    name = f"Scent Marketing {device.address[-8:]}"
 
-                dtype = detect_device_type(name)
+                sm_meta = extract_scent_marketing_metadata(adv_data) if dtype and dtype.value.startswith("scent_marketing") else None
+                if sm_meta:
+                    _LOGGER.info(
+                        "Discovered Scent Marketing device: addr=%s name=%s family=%s mfr_id=0x%04X pid=%s flag=%s raw=%s",
+                        device.address, name, dtype.value,
+                        sm_meta["mfr_id"] or 0, sm_meta["pid"], sm_meta["wifi_flag"],
+                        sm_meta["raw_hex"],
+                    )
 
-                # Show all named devices - different brands may have
-                # different BLE names. Auto-detected ones are marked.
                 self._discovered_devices[device.address] = {
                     "name": name,
                     "device_type": dtype or DeviceType.AROMA_LINK,
                     "rssi": adv_data.rssi,
                     "auto_detected": dtype is not None,
+                    "sm_metadata": sm_meta,
                 }
         except Exception as err:
             _LOGGER.error("BLE scan failed: %s", err)

--- a/custom_components/scent_assistant/const.py
+++ b/custom_components/scent_assistant/const.py
@@ -11,6 +11,9 @@ class DeviceType(StrEnum):
     TUYA_BLE = "tuya_ble"          # ShinePick QT-I300 and similar
     AROMA_LINK = "aroma_link"      # Aroma-Link WiFi+BLE diffusers
     SCENTIMENT = "scentiment"      # Scentiment Diffuser Air 2 (BLE, JSON protocol)
+    SCENT_MARKETING_AK = "scent_marketing_ak"          # Scent Marketing app, AK family (FFF0 service, simple byte commands)
+    SCENT_MARKETING_GW = "scent_marketing_gw"          # Scent Marketing app, GW family (EE01 service, framed DP protocol)
+    SCENT_MARKETING_GW_XOR = "scent_marketing_gw_xor"  # Scent Marketing app, GW family with XOR-encrypted JSON payload
 
 
 # ---------------------------------------------------------------------------
@@ -28,6 +31,44 @@ SCENTIMENT_CHAR_WRITE_UUID = "0000dead-0000-1000-8000-00805f9b34fb"  # Commands 
 SCENTIMENT_CHAR_NOTIFY_UUID = "0000fef3-0000-1000-8000-00805f9b34fb"  # State notifications
 SCENTIMENT_CHAR_INFO_UUID = "0000fef4-0000-1000-8000-00805f9b34fb"   # Device metadata (read)
 
+# Scent Marketing app — AK family (FFF0 service, simple byte commands + heartbeat)
+SM_AK_SERVICE_UUID = "0000fff0-0000-1000-8000-00805f9b34fb"
+SM_AK_CHAR_UUID = "0000fff6-0000-1000-8000-00805f9b34fb"
+
+# AK command opcodes (mirrors com.IAA360.ChengHao.Device.Data.BtDataModel).
+# Negative bytes in the Java source are decoded to their 0..255 equivalents.
+SM_AK_CMD_QUERY_INFO = 0x81           # request device name
+SM_AK_CMD_PROBE = 0x82                # request firmware/PCB info
+SM_AK_CMD_QUERY_DEVICE_TYPE = 0x89    # ask the device for its model string
+SM_AK_CMD_TIME_SYNC = 0x80            # writeTime() opcode
+SM_AK_CMD_DEVICE_NAME = 0x82          # writeDeviceName() opcode
+SM_AK_CMD_DEVICE_LABEL = 0x85         # writeDeviceLabel() opcode prefix
+SM_AK_CMD_OIL_NAME = 0x86             # writeOilName()
+SM_AK_CMD_OIL_AMOUNT = 0x8D           # writeOilAmount() opcode (0x8D = -115)
+SM_AK_CMD_CONTROL_STATE = 0x2D        # writeTotalControl(): 0x2D + bitmask
+SM_AK_CMD_SCHEDULE_V2 = 0x03          # DeviceTimeModel v2.0 schedule write
+SM_AK_CMD_SCHEDULE_V3 = 0x2A          # DeviceTimeModel v3.0 schedule write (CMD_GET_FIRMWARE_VERSION_RESEX)
+
+# AK control-state bitmask layout (LSB = onOff). Mirrors writeTotalControl()
+# which builds a binary string "lock|lamp|1|demo|fan|onOff" → int(s, 2).
+SM_AK_CTRL_BIT_ONOFF = 0
+SM_AK_CTRL_BIT_FAN = 1
+SM_AK_CTRL_BIT_DEMO = 2
+SM_AK_CTRL_BIT_RESERVED = 3   # always 1 in the Android source
+SM_AK_CTRL_BIT_LAMP = 4
+SM_AK_CTRL_BIT_LOCK = 5
+
+# Scent Marketing app — GW family (EE01 service, framed DP protocol)
+SM_GW_SERVICE_UUID = "0000ee01-0000-1000-8000-00805f9b34fb"
+SM_GW_NOTIFY_UUID = "0000ee02-0000-1000-8000-00805f9b34fb"
+SM_GW_WRITE_UUID = "0000ee03-0000-1000-8000-00805f9b34fb"
+
+# Optional alternate GW service used by WiFi-enabled GW devices. The notification
+# pipeline treats both UUIDs identically; only the encryption layer differs.
+SM_GW_ALT_SERVICE_UUID = "0000ff01-0000-1000-8000-00805f9b34fb"
+SM_GW_ALT_NOTIFY_UUID = "0000ff02-0000-1000-8000-00805f9b34fb"
+SM_GW_ALT_WRITE_UUID = "0000ff03-0000-1000-8000-00805f9b34fb"
+
 # ---------------------------------------------------------------------------
 # BLE name patterns for device detection
 # ---------------------------------------------------------------------------
@@ -37,6 +78,26 @@ BLE_NAME_PATTERNS = {
     DeviceType.TUYA_BLE: ["BT-ivy"],
     DeviceType.SCENTIMENT: ["Scentiment"],
 }
+
+# Scent Marketing devices are identified primarily by manufacturer-specific
+# data in their advertisement, not by name. These constants are used by the
+# detection logic when an AdvertisementData object is available.
+SM_MFR_ID_AK = 22851       # 0x5943 — AK family
+SM_MFR_ID_GW = 17932       # 0x460C — GW family (BLE/WiFi/Cellular)
+SM_MFR_ID_GW_ALT = 61441   # 0xF001 — GW family alternate ID (WiFi-routed devices)
+
+# GW manufacturer-data leading byte determines the encoding sub-variant.
+# 00 / unknown        → plain binary DP protocol
+# 01 / 02 / 03        → WiFi-enabled, XOR-encrypted JSON payload
+# B1 / B2             → Cellular, XOR-encrypted JSON payload (treated as XOR)
+SM_GW_FLAG_WIFI = {"01", "02", "03"}
+SM_GW_FLAG_CELLULAR = {"B1", "B2"}
+
+# AK manufacturer-data leading byte 02 → device requires periodic heartbeat
+# `E0AA55` to keep BLE notifications flowing.
+SM_AK_FLAG_HEARTBEAT = "02"
+SM_AK_HEARTBEAT_BYTES = bytes([0xE0, 0xAA, 0x55])
+SM_AK_HEARTBEAT_INTERVAL_S = 5.0
 
 # ---------------------------------------------------------------------------
 # Tuya BLE protocol constants
@@ -90,6 +151,96 @@ AL_PHASE_SPRAYING = 0x01
 AL_PHASE_PAUSED = 0x02
 
 # ---------------------------------------------------------------------------
+# Scent Marketing — GW family DP-frame protocol constants
+# ---------------------------------------------------------------------------
+
+# Frame header byte (precedes the DP-count byte).
+SM_GW_FRAME_HEADER = 0xFF
+
+# Per-DP type tags. Composite (length-prefixed) tags are 0xAF (binary) and
+# 0xBF (UTF-8). Inline boolean tags are 0x01 (generic bool), 0x11 (lock,
+# = aisbase.Constants.CMD_TYPE.CMD_GEN_CIPHER). The Tuya-style hex parser
+# also reads narrow integers as type 0x0X where X is the byte count.
+SM_GW_TYPE_BINARY = 0xAF
+SM_GW_TYPE_TEXT = 0xBF
+SM_GW_TYPE_BOOL = 0x01
+SM_GW_TYPE_LOCK = 0x11
+
+# Fixed payload lengths the firmware demands for some text DPs.
+SM_GW_LEN_NAME = 19      # DP 6 — 19-byte zero-padded device name
+SM_GW_LEN_REMARK = 16    # DP 20 — 16-byte zero-padded remark
+
+# Schedule frame (DP 4) constants. The mode byte encodes:
+#   0 = INTERVAL (timed tasks)
+#   1 = NONE / COUNT_DOWN
+#   2 = QUICK_FRAGRANCE (one-shot spray)
+SM_GW_MODE_INTERVAL = 0
+SM_GW_MODE_NONE = 1
+SM_GW_MODE_QUICK = 2
+
+# Chunk size for multi-packet writes. The Scent Marketing app uses 18 bytes
+# of payload per chunk, prefixed by a 2-byte (nonce, sequence) header — fitting
+# the 20-byte default BLE write MTU.
+SM_GW_CHUNK_SIZE = 18
+
+# Data Point IDs (subset of the app's full DP map — only the ones we read or
+# write are listed here).
+SM_GW_DP_POWER = 1
+SM_GW_DP_FAN = 2
+SM_GW_DP_LOCK = 3
+SM_GW_DP_MODE_TASKS = 4
+SM_GW_DP_VERSION = 5         # PCB + MCU version, text
+SM_GW_DP_NAME = 6            # Device name, text
+SM_GW_DP_OIL = 8
+SM_GW_DP_LIGHT = 11
+SM_GW_DP_BATTERY = 12
+SM_GW_DP_PASSWORD = 13
+SM_GW_DP_FIXED_GEAR = 14
+SM_GW_DP_CUSTOMIZE_GEAR = 15
+SM_GW_DP_REMARK = 20
+SM_GW_DP_MULTI_NOZZLE = 23
+SM_GW_DP_NOZZLE_CUSTOM = 24
+
+# Marker byte that prefixes a 5-byte ASCII password inside DP 13.
+SM_GW_PASSWORD_MARKER = 0xC0
+SM_GW_PASSWORD_OK_BYTE = 0xA1
+
+# Init/keep-alive packet sent after successful password verification.
+SM_GW_INIT_PACKET = bytes([0x01, 0x01, 0x00])
+
+# A few notification payloads the firmware sends as a heartbeat-style pulse
+# rather than a data frame. The app discards them. We do too.
+SM_GW_HEARTBEAT_HEX = "02030405060708090a0b0c0d0e"
+
+# ---------------------------------------------------------------------------
+# Scent Marketing — GW XOR-encryption lookup table
+# ---------------------------------------------------------------------------
+# 256-byte lookup table used by `HexConver.dataEncrypt`/`dataDecrypt` in the
+# Scent Marketing Android app. The encryption is a stream cipher: index into
+# this table starting at `(int(mac[8:10], 16) XOR nonce) & 0xFF`, then XOR each
+# subsequent payload byte with `SM_GW_XOR_DICT[index++]`. The first byte of
+# the on-wire packet is the random nonce that selects the starting offset.
+
+SM_GW_XOR_DICT = bytes([
+    226, 103,  87, 132,  63,  66,  59,  88, 176, 241, 188, 194, 123, 228, 209,  42,
+     19, 100, 195, 219, 189, 176, 198,  24, 138, 237, 115, 187,  61, 152,  67, 146,
+    176, 179, 140,  48, 182, 156,  17, 161, 183,  69, 137, 207,  17,  23,  47, 211,
+     70, 177, 182, 141, 226,   4,  93, 106, 105,  24, 226,   2,  50,  89, 176, 161,
+     51, 178, 182, 145, 201, 170, 180, 158, 158, 113, 175,  58,  94, 208, 239, 254,
+     88, 147,  56,  27, 161, 254,  17,  48, 108, 109, 230,   7, 134, 147, 109, 130,
+     12,  54,  36,   0,  61,   0,  41, 219, 129, 210, 119, 239,  42, 201,  35, 244,
+     80, 133,  85,   7, 146,  55,  24, 124, 199, 165,  95,  11, 231, 161,  95, 149,
+    192, 141,  35,   3, 129, 126,  45,  82,  50, 254, 114, 183, 222,   1, 163,  73,
+    121,  75,   4, 181, 179, 196, 195, 200, 176, 113, 144,  44, 110, 181,  15,  76,
+     19,  24, 231, 190, 104, 161, 131, 175,  47, 194, 186,  64, 156,  88,  37,  26,
+     80,  53,  90, 165,  78, 228, 119, 240, 253, 144, 192,  67, 109,  14,  38, 145,
+    139, 187, 101, 250, 179, 191,  68, 217,  46, 165, 120, 198,  52, 175, 106,  95,
+      3,  99,  78,  16, 226, 248, 217, 149, 230, 131,   1, 203,  57,  11,  49, 216,
+     92, 242, 131, 189,  53,  76,  93, 152,  33,  18, 138, 156, 246,   1, 227,  81,
+    167,  20,  19, 209, 253, 243,  65, 104,  80,   2,   3, 148, 129, 167, 114, 187,
+])
+
+# ---------------------------------------------------------------------------
 # Aroma-Link Cloud API constants
 # ---------------------------------------------------------------------------
 
@@ -133,6 +284,10 @@ CONF_CLOUD_PASSWORD = "cloud_password"
 CONF_CLOUD_DEVICE_ID = "cloud_device_id"
 CONF_CLOUD_USER_ID = "cloud_user_id"
 CONF_CONNECTION_MODE = "connection_mode"
+# Optional 4-char ASCII password for Scent Marketing GW devices (the
+# firmware sometimes ships locked; setting this lets the device accept
+# our control commands).
+CONF_GW_PASSWORD = "gw_password"
 
 # ---------------------------------------------------------------------------
 # Defaults

--- a/custom_components/scent_assistant/device.py
+++ b/custom_components/scent_assistant/device.py
@@ -25,6 +25,9 @@ from .protocol_ble import (
     ScheduleSetup,
     AromaLinkBleProtocol,
     ScentimentProtocol,
+    ScentMarketingAkProtocol,
+    ScentMarketingGwProtocol,
+    ScentMarketingGwXorProtocol,
     get_protocol,
     detect_device_type,
 )
@@ -46,7 +49,18 @@ class ScentDiffuserDevice:
         device_type: DeviceType | None = None,
         cloud_client: AromaLinkCloudClient | None = None,
         cloud_device_id: str | None = None,
+        sm_metadata: dict | None = None,
+        gw_password: str | None = None,
     ) -> None:
+        # Detection metadata from the config flow — populated only for
+        # Scent Marketing family devices.
+        self._sm_metadata = sm_metadata or {}
+        # Optional 4-char ASCII password for Scent Marketing GW devices.
+        # Sent proactively after every BLE connect.
+        self._gw_password = gw_password or None
+        # Trace ring-buffer for the diagnostics download.
+        self._recent_notifications: list[str] = []
+        self._recent_commands: list[str] = []
         # BLE
         self._ble_address = ble_address
         self._ble_name = ble_name or ""
@@ -60,12 +74,18 @@ class ScentDiffuserDevice:
         if device_type:
             self._device_type = device_type
         elif ble_name:
+            # No advertisement object available at this point — fall back to
+            # name-only detection (config flow performs the richer
+            # advertisement-aware detection up front and persists the result).
             self._device_type = detect_device_type(ble_name) or DeviceType.AROMA_LINK
         else:
             self._device_type = DeviceType.AROMA_LINK
 
-        # Protocol handler
-        self._protocol: BleProtocol = get_protocol(self._device_type)
+        # Protocol handler. GW-XOR needs the MAC for its keystream; GW
+        # devices with PID 98 use the Tuya-DP hex parser.
+        mac = (ble_address or "").replace(":", "")
+        pid = self._sm_metadata.get("pid") if self._sm_metadata else None
+        self._protocol: BleProtocol = get_protocol(self._device_type, mac=mac, pid=pid)
 
         # Cloud
         self._cloud: AromaLinkCloudClient | None = cloud_client
@@ -90,6 +110,53 @@ class ScentDiffuserDevice:
     @property
     def device_type(self) -> DeviceType:
         return self._device_type
+
+    @property
+    def sm_metadata(self) -> dict:
+        """Scent Marketing detection metadata (empty for other families)."""
+        return self._sm_metadata
+
+    @property
+    def recent_notifications(self) -> list[str]:
+        return list(self._recent_notifications)
+
+    @property
+    def recent_commands(self) -> list[str]:
+        return list(self._recent_commands)
+
+    @property
+    def model_name(self) -> str:
+        """Human-readable model name for HA's device-info "model" field.
+
+        For Scent Marketing devices this surfaces the detected family
+        directly on the device page, so a reporter can verify our
+        detection at a glance without digging through logs.
+        """
+        mapping = {
+            DeviceType.TUYA_BLE: "ShinePick / Tuya BLE",
+            DeviceType.AROMA_LINK: "Aroma-Link",
+            DeviceType.SCENTIMENT: "Scentiment Air 2",
+            DeviceType.SCENT_MARKETING_AK: "Scent Marketing (AK)",
+            DeviceType.SCENT_MARKETING_GW: "Scent Marketing (GW)",
+            DeviceType.SCENT_MARKETING_GW_XOR: "Scent Marketing (GW, encrypted)",
+        }
+        base = mapping.get(self._device_type, self._device_type.value)
+        # Append the PID when known — different OEMs share the same family
+        # but have distinct PIDs, useful for triage.
+        pid = self._sm_metadata.get("pid")
+        if pid is not None:
+            return f"{base} — PID {pid}"
+        return base
+
+    @property
+    def device_info(self) -> dict:
+        """Shared HA device_info block, consumed by every entity."""
+        return {
+            "identifiers": {("scent_assistant", self.unique_id)},
+            "name": self.name,
+            "manufacturer": "Scent Diffuser",
+            "model": self.model_name,
+        }
 
     @property
     def state(self) -> DiffuserState:
@@ -176,6 +243,18 @@ class ScentDiffuserDevice:
                         _LOGGER.info("BLE connected: %s", self._ble_name)
                     self._ble_has_synced_time = True
 
+                # GW family password handshake. We send unconditionally —
+                # the firmware ignores a password write on unprotected
+                # devices, and there's no reliable pre-connect way to tell
+                # which mode the device is in.
+                if self._gw_password and isinstance(
+                    self._protocol, ScentMarketingGwProtocol
+                ):
+                    try:
+                        await self._ble_send(self._protocol.build_password(self._gw_password))
+                    except Exception as err:
+                        _LOGGER.debug("Scent Marketing GW: password send failed: %s", err)
+
                 self._schedule_disconnect()
                 return True
 
@@ -204,17 +283,29 @@ class ScentDiffuserDevice:
             self._ble_connected = False
 
     async def _ble_send(self, data: bytes) -> bool:
-        """Send bytes via BLE (assumes already connected)."""
+        """Send a command via BLE.
+
+        Protocols may return more than one on-wire chunk per command — the
+        Scent Marketing GW family for instance needs (nonce, seq)-prefixed
+        18-byte chunks. We delegate the split decision to the protocol and
+        write each chunk sequentially.
+        """
         if not self._ble_client or not self._ble_client.is_connected:
             return False
-        try:
-            await self._ble_client.write_gatt_char(
-                self._protocol.write_char_uuid, data, response=True
-            )
-            return True
-        except (BleakError, asyncio.TimeoutError, OSError) as err:
-            _LOGGER.warning("BLE write failed: %s", err)
-            return False
+        chunks = self._protocol.wire_chunks(data) if data else []
+        if chunks:
+            self._recent_commands.append(data.hex())
+            if len(self._recent_commands) > 10:
+                del self._recent_commands[0]
+        for chunk in chunks:
+            try:
+                await self._ble_client.write_gatt_char(
+                    self._protocol.write_char_uuid, chunk, response=True
+                )
+            except (BleakError, asyncio.TimeoutError, OSError) as err:
+                _LOGGER.warning("BLE write failed: %s", err)
+                return False
+        return True
 
     async def _ble_execute(self, data: bytes) -> bool:
         """Connect, send command, schedule disconnect."""
@@ -227,7 +318,12 @@ class ScentDiffuserDevice:
 
     def _on_ble_notification(self, sender: int, data: bytearray) -> None:
         """Handle incoming BLE notification."""
-        updates = self._protocol.parse_notification(bytes(data))
+        raw = bytes(data)
+        # Keep a short ring-buffer of raw frames for the diagnostics export.
+        self._recent_notifications.append(raw.hex())
+        if len(self._recent_notifications) > 20:
+            del self._recent_notifications[0]
+        updates = self._protocol.parse_notification(raw)
         if not updates:
             return
 
@@ -267,6 +363,25 @@ class ScentDiffuserDevice:
         if "rgb_color" in updates:
             self._state.rgb_color = updates["rgb_color"]
             changed = True
+        # Scent Marketing GW family — new state fields
+        if "lock" in updates:
+            self._state.lock = updates["lock"]
+            changed = True
+        if "oil_remaining" in updates:
+            self._state.oil_remaining = updates["oil_remaining"]
+            changed = True
+        if "light_on" in updates:
+            self._state.light_on = updates["light_on"]
+            changed = True
+        if "device_name" in updates:
+            self._state.device_name = updates["device_name"]
+            changed = True
+        if "password_required" in updates:
+            self._state.password_required = updates["password_required"]
+            changed = True
+        if "firmware_version" in updates:
+            self._state.firmware_version = updates["firmware_version"]
+            changed = True
 
         if changed:
             self._notify_state_changed()
@@ -298,16 +413,46 @@ class ScentDiffuserDevice:
         return False
 
     async def set_fan(self, on: bool) -> bool:
-        """Turn fan on or off (Aroma-Link only, BLE only)."""
-        if not self.supports_fan or not self._ble_address:
+        """Turn fan on or off (Aroma-Link + Scent Marketing AK)."""
+        if not self._ble_address:
             return False
-
-        if isinstance(self._protocol, AromaLinkBleProtocol):
-            cmd = self._protocol.build_fan(on)
+        proto = self._protocol
+        if isinstance(proto, (AromaLinkBleProtocol, ScentMarketingAkProtocol)):
+            cmd = proto.build_fan(on)
             if await self._ble_execute(cmd):
                 self._state.fan = on
                 self._notify_state_changed()
                 return True
+        return False
+
+    async def set_lock(self, on: bool) -> bool:
+        """Toggle child-lock (Scent Marketing AK + GW + GW-XOR)."""
+        if not self._ble_address:
+            return False
+        proto = self._protocol
+        if isinstance(proto, (ScentMarketingAkProtocol, ScentMarketingGwProtocol)):
+            cmd = proto.build_lock(on)
+            if await self._ble_execute(cmd):
+                self._state.lock = on
+                self._notify_state_changed()
+                return True
+        return False
+
+    async def set_lamp(self, on: bool) -> bool:
+        """Toggle auxiliary lamp (Scent Marketing AK lamp-bit, GW DP-11 light)."""
+        if not self._ble_address:
+            return False
+        proto = self._protocol
+        if isinstance(proto, ScentMarketingAkProtocol):
+            cmd = proto.build_lamp(on)
+        elif isinstance(proto, ScentMarketingGwProtocol):
+            cmd = proto.build_light(on)
+        else:
+            return False
+        if await self._ble_execute(cmd):
+            self._state.light_on = on
+            self._notify_state_changed()
+            return True
         return False
 
     async def set_level(self, level: int) -> bool:
@@ -399,6 +544,18 @@ class ScentDiffuserDevice:
                     enabled=enabled, work_seconds=work, pause_seconds=pause,
                 )
                 cmd = self._protocol.build_schedule(weekday_mask, [slot])
+            elif isinstance(self._protocol, ScentMarketingGwProtocol):
+                slot = ScheduleSlot(
+                    start_hour=s_h, start_minute=s_m, end_hour=e_h, end_minute=e_m,
+                    enabled=enabled, work_seconds=work, pause_seconds=pause,
+                )
+                cmd = self._protocol.build_schedule([slot], weekday_mask=weekday_mask)
+            elif isinstance(self._protocol, ScentMarketingAkProtocol):
+                slot = ScheduleSlot(
+                    start_hour=s_h, start_minute=s_m, end_hour=e_h, end_minute=e_m,
+                    enabled=enabled, work_seconds=work, pause_seconds=pause,
+                )
+                cmd = self._protocol.build_schedule_v2(slot)
 
             if cmd and await self._ble_execute(cmd):
                 self._notify_state_changed()

--- a/custom_components/scent_assistant/diagnostics.py
+++ b/custom_components/scent_assistant/diagnostics.py
@@ -1,0 +1,77 @@
+"""Diagnostics support for the Scent Diffuser integration.
+
+A reporter can click "Download Diagnostics" on the device page in HA and
+attach the resulting JSON to a bug report; everything we need to validate
+or debug detection + protocol behaviour is contained here.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import (
+    DOMAIN,
+    CONF_BLE_ADDRESS,
+    CONF_CLOUD_PASSWORD,
+    CONF_CLOUD_USERNAME,
+    CONF_GW_PASSWORD,
+)
+from .device import ScentDiffuserDevice
+
+TO_REDACT = {
+    CONF_BLE_ADDRESS, CONF_CLOUD_USERNAME, CONF_CLOUD_PASSWORD,
+    CONF_GW_PASSWORD, "mac_from_adv",
+}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    device: ScentDiffuserDevice | None = hass.data.get(DOMAIN, {}).get(entry.entry_id)
+
+    state_snapshot: dict[str, Any] = {}
+    if device is not None:
+        s = device.state
+        state_snapshot = {
+            "power": s.power,
+            "phase": s.phase,
+            "fan": s.fan,
+            "level": s.level,
+            "battery": s.battery,
+            "oil_remaining": s.oil_remaining,
+            "lock": s.lock,
+            "light_on": s.light_on,
+            "device_name": s.device_name,
+            "password_required": s.password_required,
+            "firmware_version": s.firmware_version,
+            "work_seconds": s.work_seconds,
+            "pause_seconds": s.pause_seconds,
+        }
+
+    payload: dict[str, Any] = {
+        "entry": {
+            "title": entry.title,
+            "data": async_redact_data(dict(entry.data), TO_REDACT),
+            "options": dict(entry.options),
+        },
+        "device": {
+            "device_type": device.device_type.value if device else None,
+            "model": device.model_name if device else None,
+            "available": device.available if device else None,
+            "connection_mode": device.connection_mode if device else None,
+            "supports_fan": device.supports_fan if device else None,
+            "supports_cloud": device.supports_cloud if device else None,
+        },
+        "sm_metadata": async_redact_data(
+            dict(device.sm_metadata) if device and device.sm_metadata else {},
+            TO_REDACT,
+        ),
+        "state": state_snapshot,
+        "recent_notifications_hex": device.recent_notifications if device else [],
+        "recent_commands_hex": device.recent_commands if device else [],
+    }
+    return payload

--- a/custom_components/scent_assistant/manifest.json
+++ b/custom_components/scent_assistant/manifest.json
@@ -4,7 +4,11 @@
   "bluetooth": [
     { "local_name": "Scent *" },
     { "local_name": "BT-ivy*" },
-    { "local_name": "Scentiment*" }
+    { "local_name": "Scentiment*" },
+    { "local_name": "SA_*" },
+    { "manufacturer_id": 22851 },
+    { "manufacturer_id": 17932 },
+    { "manufacturer_id": 61441 }
   ],
   "codeowners": ["@mr-sparks"],
   "config_flow": true,
@@ -13,5 +17,5 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/mr-sparks/scent-assistant/issues",
   "requirements": ["bleak>=0.21.0"],
-  "version": "1.1.0"
+  "version": "1.2.0-beta.1"
 }

--- a/custom_components/scent_assistant/protocol_ble.py
+++ b/custom_components/scent_assistant/protocol_ble.py
@@ -10,6 +10,28 @@ from .const import (
     DeviceType,
     SERVICE_UUID, CHAR_WRITE_UUID, CHAR_NOTIFY_UUID,
     SCENTIMENT_SERVICE_UUID, SCENTIMENT_CHAR_WRITE_UUID, SCENTIMENT_CHAR_NOTIFY_UUID,
+    SM_AK_SERVICE_UUID, SM_AK_CHAR_UUID,
+    SM_AK_CMD_QUERY_INFO, SM_AK_CMD_PROBE, SM_AK_CMD_QUERY_DEVICE_TYPE,
+    SM_AK_CMD_TIME_SYNC, SM_AK_CMD_DEVICE_NAME, SM_AK_CMD_DEVICE_LABEL,
+    SM_AK_CMD_OIL_NAME, SM_AK_CMD_OIL_AMOUNT, SM_AK_CMD_CONTROL_STATE,
+    SM_AK_CMD_SCHEDULE_V2, SM_AK_CMD_SCHEDULE_V3,
+    SM_AK_CTRL_BIT_ONOFF, SM_AK_CTRL_BIT_FAN, SM_AK_CTRL_BIT_DEMO,
+    SM_AK_CTRL_BIT_RESERVED, SM_AK_CTRL_BIT_LAMP, SM_AK_CTRL_BIT_LOCK,
+    SM_GW_SERVICE_UUID, SM_GW_NOTIFY_UUID, SM_GW_WRITE_UUID,
+    SM_MFR_ID_AK, SM_MFR_ID_GW, SM_MFR_ID_GW_ALT,
+    SM_GW_FLAG_WIFI, SM_GW_FLAG_CELLULAR,
+    SM_AK_FLAG_HEARTBEAT, SM_AK_HEARTBEAT_BYTES,
+    SM_GW_FRAME_HEADER, SM_GW_TYPE_BINARY, SM_GW_TYPE_TEXT, SM_GW_CHUNK_SIZE,
+    SM_GW_TYPE_BOOL, SM_GW_TYPE_LOCK,
+    SM_GW_LEN_NAME, SM_GW_LEN_REMARK,
+    SM_GW_MODE_INTERVAL, SM_GW_MODE_NONE, SM_GW_MODE_QUICK,
+    SM_GW_DP_POWER, SM_GW_DP_FAN, SM_GW_DP_LOCK, SM_GW_DP_MODE_TASKS,
+    SM_GW_DP_VERSION, SM_GW_DP_NAME, SM_GW_DP_OIL, SM_GW_DP_LIGHT,
+    SM_GW_DP_BATTERY, SM_GW_DP_PASSWORD, SM_GW_DP_FIXED_GEAR,
+    SM_GW_DP_CUSTOMIZE_GEAR, SM_GW_DP_REMARK,
+    SM_GW_PASSWORD_MARKER, SM_GW_PASSWORD_OK_BYTE,
+    SM_GW_INIT_PACKET, SM_GW_HEARTBEAT_HEX, SM_GW_XOR_DICT,
+    BLE_NAME_PATTERNS,
     TUYA_HEADER, TUYA_VERSION,
     TUYA_CMD_DP_WRITE, TUYA_CMD_DP_REPORT, TUYA_CMD_QUERY, TUYA_CMD_TIME_SYNC,
     TUYA_DP_TYPE_BOOL, TUYA_DP_TYPE_RAW,
@@ -24,6 +46,12 @@ from .const import (
 )
 
 import json
+import random
+import time
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from bleak.backends.scanner import AdvertisementData
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -50,6 +78,13 @@ class DiffuserState:
     start_minute: int = 0
     end_hour: int = 23
     end_minute: int = 59
+    # Scent Marketing GW-only
+    lock: bool | None = None           # child-lock state
+    oil_remaining: int | None = None   # percent 0-100
+    light_on: bool | None = None       # auxiliary LED state
+    device_name: str | None = None     # user-set device name (DP 6)
+    password_required: bool | None = None  # GW device demands password auth
+    firmware_version: str | None = None    # PCB+MCU version string
 
 
 @dataclass
@@ -111,6 +146,15 @@ class BleProtocol(ABC):
     @abstractmethod
     def parse_notification(self, data: bytes) -> dict:
         """Parse a notification from the device. Returns dict of state updates."""
+
+    def wire_chunks(self, frame: bytes) -> list[bytes]:
+        """Split a command into on-wire chunks.
+
+        Most protocols send a command as a single GATT write. The Scent
+        Marketing GW family overrides this to apply 18-byte chunking with
+        a per-chunk (nonce, seq) header.
+        """
+        return [frame]
 
     def supports_fan(self) -> bool:
         """Whether this device has a fan control."""
@@ -476,30 +520,848 @@ class ScentimentProtocol(BleProtocol):
 
 
 # ---------------------------------------------------------------------------
+# Scent Marketing app — three protocol families
+# ---------------------------------------------------------------------------
+#
+# The Scent Marketing Android app supports three protocol families. They are
+# distinguished primarily by manufacturer-specific data in BLE advertisement
+# packets, not by device name (the app routes purely on manufacturer IDs):
+#
+#   * AK family   — 0x5943 (22851). Service FFF0 / Char FFF6. Simple bytes,
+#                   optionally with a periodic E0AA55 heartbeat.
+#   * GW family   — 0x460C (17932) or 0xF001 (61441). Service EE01 / Notify
+#                   EE02 / Write EE03. A length-prefixed data-point frame
+#                   wrapped in 18-byte chunks with a (nonce, seq) header per
+#                   chunk. The first byte of manufacturer data determines
+#                   whether the inner payload is plain binary or wrapped in
+#                   an additional XOR stream-cipher layer (01/02/03 = WiFi
+#                   variant with XOR encryption; B1/B2 = cellular with XOR;
+#                   anything else = plain binary).
+#
+# All three implementations live in this module. Until @angeldero or another
+# reporter validates against real hardware, treat them as beta-quality.
+
+
+class ScentMarketingAkProtocol(BleProtocol):
+    """Scent Marketing — AK family (FFF0 service).
+
+    Commands and responses share `FFF6`. A response's first byte is the
+    opcode of the corresponding read/write. Many of the writes here are
+    portable copies of `BtDataModel.writeXxx()` and `TotalControlModel`
+    from the decompiled app.
+    """
+
+    device_type = DeviceType.SCENT_MARKETING_AK
+    service_uuid = SM_AK_SERVICE_UUID
+    write_char_uuid = SM_AK_CHAR_UUID
+    notify_char_uuid = SM_AK_CHAR_UUID
+
+    def __init__(self) -> None:
+        # We track the on-device control bitmask locally so a "set only the
+        # power bit" command doesn't clobber lamp/fan/lock state. Updated
+        # whenever the device pushes a 0x4D control-state notification.
+        self._ctrl_bits = {
+            SM_AK_CTRL_BIT_ONOFF: False,
+            SM_AK_CTRL_BIT_FAN: False,
+            SM_AK_CTRL_BIT_DEMO: False,
+            SM_AK_CTRL_BIT_LAMP: False,
+            SM_AK_CTRL_BIT_LOCK: False,
+        }
+
+    # ------------------------------------------------------------------
+    # Control-state helpers
+    # ------------------------------------------------------------------
+
+    def _build_control(self, override_bit: int | None = None,
+                       override_value: bool = False) -> bytes:
+        """Build a 0x2D control-write with at most one bit overridden.
+
+        Mirrors `TotalControlModel.writeTotalControl()`: 6-bit mask where
+        bit 3 is reserved-always-1 and bits 5..0 are
+        lock|lamp|1|demo|fan|onOff. Pass `override_bit` to flip a single
+        bit relative to the cached on-device state.
+        """
+        bits = dict(self._ctrl_bits)
+        if override_bit is not None:
+            bits[override_bit] = override_value
+        mask = (1 << SM_AK_CTRL_BIT_RESERVED)
+        for bit in (SM_AK_CTRL_BIT_ONOFF, SM_AK_CTRL_BIT_FAN,
+                    SM_AK_CTRL_BIT_DEMO, SM_AK_CTRL_BIT_LAMP,
+                    SM_AK_CTRL_BIT_LOCK):
+            if bits.get(bit):
+                mask |= 1 << bit
+        return bytes([SM_AK_CMD_CONTROL_STATE, mask & 0xFF])
+
+    def build_power(self, on: bool) -> bytes:
+        return self._build_control(SM_AK_CTRL_BIT_ONOFF, on)
+
+    def build_lock(self, on: bool) -> bytes:
+        return self._build_control(SM_AK_CTRL_BIT_LOCK, on)
+
+    def build_lamp(self, on: bool) -> bytes:
+        return self._build_control(SM_AK_CTRL_BIT_LAMP, on)
+
+    def build_fan(self, on: bool) -> bytes:
+        return self._build_control(SM_AK_CTRL_BIT_FAN, on)
+
+    def supports_fan(self) -> bool:
+        # The AK control bitmask carries a fan bit. We don't yet know
+        # which models actually wire it up, but exposing the switch lets
+        # users discover that empirically.
+        return True
+
+    # ------------------------------------------------------------------
+    # Misc writes
+    # ------------------------------------------------------------------
+
+    def build_query(self) -> bytes:
+        return bytes([SM_AK_CMD_QUERY_INFO])
+
+    def build_heartbeat(self) -> bytes:
+        return SM_AK_HEARTBEAT_BYTES
+
+    def build_time_sync(self, now: datetime | None = None) -> bytes:
+        """Port of `BtDataModel.writeTime()` — opcode + YY MM DD HH MM SS WD."""
+        if now is None:
+            now = datetime.now()
+        return bytes([
+            SM_AK_CMD_TIME_SYNC,
+            now.year % 100, now.month, now.day,
+            now.hour, now.minute, now.second,
+            now.isoweekday() % 7,  # 0=Sun .. 6=Sat per the AK firmware
+        ])
+
+    def build_device_name(self, name: str) -> bytes:
+        """Port of `BtDataModel.writeDeviceName()` — UTF-8, max 16 bytes."""
+        payload = name.encode("utf-8")[:16]
+        return bytes([SM_AK_CMD_DEVICE_NAME, len(payload)]) + payload
+
+    def build_oil_amount(self, remaining: int, battery_pct: int) -> bytes:
+        """Port of `BtDataModel.writeOilAmount()`."""
+        return bytes([
+            SM_AK_CMD_OIL_AMOUNT,
+            (remaining >> 8) & 0xFF, remaining & 0xFF,
+            battery_pct & 0xFF,
+        ])
+
+    def build_schedule_v2(self, slot: ScheduleSlot, index: int = 1) -> bytes:
+        """Port of `DeviceTimeModel.writeData()` v2.0 schedule write."""
+        flag_bits = (1 << 4) if slot.enabled else 0  # bit 4 = timeOnOff
+        flag_bits |= (index & 0x0F)
+        repeat = 0  # repeat mask is computed from ScheduleSlot.weekday in HA
+        out = bytearray(15)
+        out[0] = SM_AK_CMD_SCHEDULE_V2
+        out[1] = flag_bits & 0xFF
+        out[2] = slot.start_hour & 0xFF
+        out[3] = slot.start_minute & 0xFF
+        out[4] = slot.end_hour & 0xFF
+        out[5] = slot.end_minute & 0xFF
+        out[6] = repeat & 0x7F
+        # Custom-grade mode is encoded as grade=0; we map work/pause via
+        # the extended (19-byte) layout below.
+        out[7] = 0
+        custom = bytearray([
+            (slot.work_seconds >> 8) & 0xFF, slot.work_seconds & 0xFF,
+            (slot.pause_seconds >> 8) & 0xFF, slot.pause_seconds & 0xFF,
+        ])
+        return bytes(out) + bytes(custom)
+
+    # ------------------------------------------------------------------
+    # Notification parsing
+    # ------------------------------------------------------------------
+
+    def parse_notification(self, data: bytes) -> dict:
+        """Parse an AK status notification by opcode (first byte).
+
+        Mirrors `BtDataModel.readBluetoothData(byte[])` — the response
+        opcode picks the layout.
+        """
+        if not data:
+            return {}
+        result: dict = {}
+        op = data[0] & 0xFF
+
+        if op == 0x4D and len(data) >= 2:  # control state
+            mask = data[1] & 0xFF
+            self._ctrl_bits[SM_AK_CTRL_BIT_ONOFF] = bool(mask & (1 << SM_AK_CTRL_BIT_ONOFF))
+            self._ctrl_bits[SM_AK_CTRL_BIT_FAN] = bool(mask & (1 << SM_AK_CTRL_BIT_FAN))
+            self._ctrl_bits[SM_AK_CTRL_BIT_DEMO] = bool(mask & (1 << SM_AK_CTRL_BIT_DEMO))
+            self._ctrl_bits[SM_AK_CTRL_BIT_LAMP] = bool(mask & (1 << SM_AK_CTRL_BIT_LAMP))
+            self._ctrl_bits[SM_AK_CTRL_BIT_LOCK] = bool(mask & (1 << SM_AK_CTRL_BIT_LOCK))
+            result["power"] = self._ctrl_bits[SM_AK_CTRL_BIT_ONOFF]
+            result["phase"] = "idle" if result["power"] else "off"
+            result["fan"] = self._ctrl_bits[SM_AK_CTRL_BIT_FAN]
+            result["lock"] = self._ctrl_bits[SM_AK_CTRL_BIT_LOCK]
+            result["light_on"] = self._ctrl_bits[SM_AK_CTRL_BIT_LAMP]
+
+        elif op == 0x4B and len(data) >= 4:  # battery + oil-remaining
+            result["battery"] = data[1] & 0xFF
+            # Bytes 2..3 = aroma0 total (u16), 4..5 = remainder etc.; we
+            # only surface the first nozzle's remainder as a percentage.
+            if len(data) >= 8:
+                total = (data[4] << 8) | data[5]
+                remainder = (data[6] << 8) | data[7]
+                if total > 0:
+                    result["oil_remaining"] = max(0, min(100, int(100 * remainder / total)))
+
+        elif op == 0x42 and len(data) >= 2:  # device name (BLE v3 push)
+            result["device_name"] = data[1:].rstrip(b"\x00").decode("utf-8", errors="replace").strip()
+
+        elif op == 0x44 and len(data) >= 17:  # PCB + Equipment firmware version
+            pcb = data[1:17].rstrip(b"\x00").decode("utf-8", errors="replace").strip()
+            eqv = data[17:].rstrip(b"\x00").decode("utf-8", errors="replace").strip()
+            result["firmware_version"] = f"{pcb} / {eqv}".strip(" /")
+
+        elif op == 0x82 and len(data) >= 2:  # PCB version (BLE v2)
+            result["firmware_version"] = data[1:].rstrip(b"\x00").decode("utf-8", errors="replace").strip()
+
+        elif op == 0x88 and len(data) >= 2:  # equipment version
+            version = data[1:].rstrip(b"\x00").decode("utf-8", errors="replace").strip()
+            if version:
+                result["firmware_version"] = version
+
+        return result
+
+
+class ScentMarketingGwProtocol(BleProtocol):
+    """Scent Marketing — GW family (EE01 service), plain binary DP protocol.
+
+    Frame layout (inside the multi-packet envelope):
+
+        FF <dp_count>
+            <dp_id:u16-be> <type=AF> <len:u16-be> <payload...>     # composite
+            <dp_id:u16-be> <inline-value>                          # inline DPs
+            ...
+
+    Composite DPs use type tag 0xAF (binary) or 0xBF (UTF-8 text). Inline
+    DPs (POWER, LOCK) have no length prefix; their payload size is implied
+    by the DP-ID.
+
+    On the wire every frame is chopped into 18-byte chunks, each prefixed
+    with a (nonce_byte, sequence_byte) header. If the last chunk happens to
+    be exactly 18 bytes, an extra terminator chunk of just (nonce, count+1)
+    must be appended.
+    """
+
+    device_type = DeviceType.SCENT_MARKETING_GW
+    service_uuid = SM_GW_SERVICE_UUID
+    write_char_uuid = SM_GW_WRITE_UUID
+    notify_char_uuid = SM_GW_NOTIFY_UUID
+
+    # The chunk reassembly state lives on the protocol instance because
+    # GW notifications arrive as a stream of small fragments — we cannot
+    # parse a single chunk in isolation.
+    def __init__(self, tuya_dp_mode: bool = False) -> None:
+        self._notify_buffer: list[bytes] = []
+        # Some GW firmwares (those advertising PID 98) push their state
+        # in Tuya-DP hex-string format instead of the regular binary
+        # frame. The wire layout is the same; only the type-tag-driven
+        # length decoding differs.
+        self._tuya_dp_mode = tuya_dp_mode
+
+    # ------------------------------------------------------------------
+    # Frame builders
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _u16_be(v: int) -> bytes:
+        return bytes([(v >> 8) & 0xFF, v & 0xFF])
+
+    @classmethod
+    def _build_bool_dp(cls, dp_id: int, on: bool, type_tag: int = SM_GW_TYPE_BOOL) -> bytes:
+        """Build an inline boolean DP `[DP-ID:2][type][value:1]`.
+
+        `type_tag` defaults to 0x01 (generic bool) — pass 0x11 for the
+        lock DP, since the firmware encodes it as `CMD_GEN_CIPHER`.
+        """
+        return cls._u16_be(dp_id) + bytes([type_tag, 0x01 if on else 0x00])
+
+    @staticmethod
+    def _padded_utf8(s: str, length: int) -> bytes:
+        """Pad a string to exactly `length` bytes (zero-fill, truncate)."""
+        data = s.encode("utf-8")[:length]
+        return data + b"\x00" * (length - len(data))
+
+    @classmethod
+    def _build_composite_dp(
+        cls, dp_id: int, payload: bytes, type_tag: int = SM_GW_TYPE_BINARY
+    ) -> bytes:
+        return cls._u16_be(dp_id) + bytes([type_tag]) + cls._u16_be(len(payload)) + payload
+
+    @classmethod
+    def _build_frame(cls, dp_packets: list[bytes]) -> bytes:
+        """Wrap a list of encoded DPs into an FF-prefixed frame."""
+        return bytes([SM_GW_FRAME_HEADER, len(dp_packets)]) + b"".join(dp_packets)
+
+    @staticmethod
+    def chunk_for_transport(frame: bytes, nonce: int | None = None) -> list[bytes]:
+        """Split a frame into (nonce, seq)-prefixed 18-byte transport chunks."""
+        if nonce is None:
+            nonce = random.randint(0, 0xFF)
+        chunks: list[bytes] = []
+        for i in range(0, len(frame), SM_GW_CHUNK_SIZE):
+            seq = (i // SM_GW_CHUNK_SIZE) + 1
+            chunks.append(bytes([nonce, seq]) + frame[i:i + SM_GW_CHUNK_SIZE])
+        # The app appends a terminator chunk if the last payload chunk is
+        # exactly the full chunk size (the receiver uses sub-chunk-size
+        # packets as an end-of-frame marker).
+        if chunks and len(chunks[-1]) - 2 == SM_GW_CHUNK_SIZE:
+            chunks.append(bytes([nonce, len(chunks) + 1]))
+        return chunks
+
+    def wire_chunks(self, frame: bytes) -> list[bytes]:
+        return self.chunk_for_transport(frame)
+
+    # ------------------------------------------------------------------
+    # Commands
+    # ------------------------------------------------------------------
+
+    def build_power(self, on: bool) -> bytes:
+        return self._build_frame([self._build_bool_dp(SM_GW_DP_POWER, on)])
+
+    def build_lock(self, on: bool) -> bytes:
+        return self._build_frame([
+            self._build_bool_dp(SM_GW_DP_LOCK, on, type_tag=SM_GW_TYPE_LOCK),
+        ])
+
+    def build_light(self, on: bool, light_type: int = 1) -> bytes:
+        """Build a DP-11 light command. `light_type` mirrors the firmware
+        Light.getType() field (1 = simple on/off, 3/7 = colour wheel)."""
+        if light_type == 1:
+            payload = bytes([1, 0x01 if on else 0x00])
+        else:
+            payload = bytes([light_type & 0xFF, 0x01 if on else 0x00])
+        return self._build_frame([self._build_composite_dp(SM_GW_DP_LIGHT, payload)])
+
+    def build_device_name(self, name: str) -> bytes:
+        """Build a DP-6 device-name write. Always 19 bytes zero-padded."""
+        return self._build_frame([
+            self._build_composite_dp(
+                SM_GW_DP_NAME, self._padded_utf8(name, SM_GW_LEN_NAME),
+                type_tag=SM_GW_TYPE_TEXT,
+            ),
+        ])
+
+    def build_remark(self, remark: str) -> bytes:
+        """Build a DP-20 remark write. Always 16 bytes zero-padded."""
+        return self._build_frame([
+            self._build_composite_dp(
+                SM_GW_DP_REMARK, self._padded_utf8(remark, SM_GW_LEN_REMARK),
+            ),
+        ])
+
+    def build_wind_sensing(self, on: bool, pairing_status: int = 0,
+                           wind_status: int = 0, battery_pct: int = 0) -> bytes:
+        """Build a DP-28 wind-sensing command. Port of `writeWind()`."""
+        payload = bytes([
+            1,                              # presence flag
+            0x01 if on else 0x00,
+            pairing_status & 0xFF,
+            wind_status & 0xFF,
+            battery_pct & 0xFF,
+        ])
+        return self._build_frame([self._build_composite_dp(0x1C, payload)])
+
+    def build_time_sync(self, now: datetime | None = None) -> bytes:
+        """Build a DP-10 clock-sync command (7 bytes BCD-ish)."""
+        if now is None:
+            now = datetime.now()
+        weekday = (now.isoweekday() % 7)  # 0=Sun .. 6=Sat
+        payload = bytes([
+            now.year % 100, now.month, now.day,
+            weekday,
+            now.hour, now.minute, now.second,
+        ])
+        return self._build_frame([self._build_composite_dp(0x0A, payload)])
+
+    def build_query(self) -> bytes:
+        # The GW firmware autonomously pushes its full DP state after the
+        # init handshake, so an explicit query is rarely needed. We send
+        # the init packet here, which causes the device to re-emit state.
+        return SM_GW_INIT_PACKET
+
+    def build_init_ack(self) -> bytes:
+        """Build the init/ACK packet that follows successful password auth."""
+        return SM_GW_INIT_PACKET
+
+    def build_password(self, password: str) -> bytes:
+        """Build a DP-13 password-check write.
+
+        Mirrors `BluetoothDataParser.encodePassword()`: a composite DP-13
+        with a fixed declared length of 5 bytes, leading with the
+        `0xC0` marker byte followed by a 4-byte ASCII password.
+        """
+        pwd_bytes = password.encode("ascii")[:4].ljust(4, b"\x00")
+        payload = bytes([SM_GW_PASSWORD_MARKER]) + pwd_bytes
+        # We hand-build the DP because the declared length (5) is fixed
+        # by the protocol, not derived from the actual payload length.
+        dp = self._u16_be(SM_GW_DP_PASSWORD) + bytes([
+            SM_GW_TYPE_BINARY, 0x00, 0x05,
+        ]) + payload
+        return self._build_frame([dp])
+
+    # ------------------------------------------------------------------
+    # Schedule (DP 4) — interval tasks + customize-gear
+    # ------------------------------------------------------------------
+
+    def build_schedule(self, slots: list["ScheduleSlot"],
+                       weekday_mask: int = 0x7F) -> bytes:
+        """Port of `GwBleCtrl.handleTasksAndPower()` for single-nozzle
+        devices (modelNode != 23).
+
+        Layout (everything in big-endian):
+
+            FF NN                            frame header + DP count
+            00 04 AF <len:u16>               DP 4 header
+            01 00                            sub-version / reserved
+            00 <task_count>                  task count u16
+            for each task: 7 bytes
+                [enabled<<7 | weekday_mask:7] [start_h] [start_m]
+                [end_h] [end_m] [spray=1] [power=intensity]
+            01 64 00 <countdown_power>       reserved + countdown sentinel
+            02 01 2C <quick_power>           quick-fragrance sentinel
+            (optionally) 00 0F AF 00 0C ...  customize-gear block
+
+        We do not currently emit the customize-gear block (we leave it
+        for users who explicitly opt-in to per-slot custom timings via
+        the integration's existing schedule service).
+        """
+        task_count = len(slots)
+        payload = bytearray()
+        payload += bytes([0x01, 0x00])                # sub-version
+        payload += bytes([0x00, task_count & 0xFF])   # task count u16
+        for slot in slots:
+            day_bits = weekday_mask & 0x7F
+            flags = day_bits | (0x80 if slot.enabled else 0x00)
+            power = slot.work_seconds if slot.work_seconds <= 0xFF else 0xFF
+            payload += bytes([
+                flags & 0xFF,
+                slot.start_hour & 0xFF, slot.start_minute & 0xFF,
+                slot.end_hour & 0xFF, slot.end_minute & 0xFF,
+                0x01,                       # spray = 1
+                power & 0xFF,
+            ])
+        payload += bytes([0x01, 0x64, 0x00, 0x00])    # countdown sentinel
+        payload += bytes([0x02, 0x01, 0x2C, 0x00])    # quick-fragrance sentinel
+        dp4 = self._build_composite_dp(SM_GW_DP_MODE_TASKS, bytes(payload))
+        return self._build_frame([dp4])
+
+    # ------------------------------------------------------------------
+    # Notification parsing
+    # ------------------------------------------------------------------
+
+    def handle_transport_chunk(self, chunk: bytes) -> bytes | None:
+        """Feed an on-wire 20-byte chunk into the reassembly buffer.
+
+        Returns the reassembled inner frame once a short (< 20-byte) chunk
+        is received signalling end-of-frame, otherwise None.
+        """
+        if len(chunk) < 2:
+            return None
+        # Strip the (nonce, seq) header.
+        self._notify_buffer.append(chunk[2:])
+        if len(chunk) < 20:
+            frame = b"".join(self._notify_buffer)
+            self._notify_buffer.clear()
+            # Some firmwares periodically send a noise pulse rather than a
+            # data frame; the app discards them.
+            if frame.hex() == SM_GW_HEARTBEAT_HEX:
+                return None
+            return frame
+        return None
+
+    def parse_notification(self, data: bytes) -> dict:
+        """Parse a single on-wire chunk. Returns updates only on full frames."""
+        frame = self.handle_transport_chunk(data)
+        if frame is None:
+            return {}
+        return self.parse_frame(frame)
+
+    def parse_frame(self, frame: bytes) -> dict:
+        """Parse a reassembled DP frame."""
+        if self._tuya_dp_mode:
+            return self._parse_frame_tuya(frame)
+        result: dict = {}
+        # The frame begins with two bytes that the app reads as a 16-bit
+        # DP-ID, before any framing header. The original parser starts at
+        # index 2 and treats those leading bytes as throw-away count info.
+        idx = 2
+        while idx < len(frame):
+            if idx + 1 >= len(frame):
+                break
+            dp_id = (frame[idx] << 8) | frame[idx + 1]
+            idx += 2
+            try:
+                idx = self._parse_dp(frame, idx, dp_id, result)
+            except (IndexError, ValueError) as err:
+                _LOGGER.debug("Scent Marketing GW: DP parse failed at idx=%d dp=%d: %s",
+                              idx, dp_id, err)
+                break
+        return result
+
+    def _parse_frame_tuya(self, frame: bytes) -> dict:
+        """Parse a PID-98 frame using Tuya-style type-driven length decoding.
+
+        Mirrors `HexConver.dpStringToJson`. The wire layout is identical to
+        the regular frame but the parser interprets the type-tag byte as
+        a hint for the value length (low-nibble = byte-count, 0xAF / 0xBF
+        = length-prefixed).
+        """
+        result: dict = {}
+        if len(frame) < 2:
+            return result
+        dp_count = frame[1] & 0xFF
+        idx = 2
+        for _ in range(dp_count):
+            if idx + 3 > len(frame):
+                break
+            dp_id = (frame[idx] << 8) | frame[idx + 1]
+            type_tag = frame[idx + 2]
+            idx += 3
+            if type_tag in (SM_GW_TYPE_BINARY, SM_GW_TYPE_TEXT):
+                if idx + 2 > len(frame):
+                    break
+                length = (frame[idx] << 8) | frame[idx + 1]
+                idx += 2
+                payload = frame[idx:idx + length]
+                idx += length
+                # Reuse the regular DP handler by faking it received a
+                # composite payload.
+                self._dispatch_composite(dp_id, type_tag, payload, result)
+            else:
+                size = type_tag & 0x0F
+                payload = frame[idx:idx + size]
+                idx += size
+                if dp_id == SM_GW_DP_POWER and len(payload) >= 1:
+                    result["power"] = payload[0] == 1
+                    result["phase"] = "idle" if result["power"] else "off"
+                elif dp_id == SM_GW_DP_LOCK and len(payload) >= 1:
+                    result["lock"] = payload[0] == 1
+        return result
+
+    def _dispatch_composite(self, dp_id: int, type_tag: int, payload: bytes, result: dict) -> None:
+        """Composite-DP dispatcher shared by binary + Tuya parsers."""
+        if dp_id == SM_GW_DP_VERSION:
+            result["firmware_version"] = payload.split(b"\x00", 1)[0].decode("ascii", errors="replace")
+        elif dp_id == SM_GW_DP_NAME:
+            text = payload.rstrip(b"\x00").decode("utf-8", errors="replace").strip()
+            if text:
+                result["device_name"] = text
+        elif dp_id == SM_GW_DP_REMARK:
+            text = payload.rstrip(b"\x00").decode("utf-8", errors="replace").strip()
+            if text:
+                result["remark"] = text
+        elif dp_id == SM_GW_DP_BATTERY and len(payload) >= 3:
+            result["battery"] = payload[1] & 0xFF
+        elif dp_id == SM_GW_DP_OIL and len(payload) >= 1:
+            first = payload[0] & 0xFF
+            if 113 <= first <= 127 and len(payload) >= 7:
+                result["oil_remaining"] = (payload[5] << 8) | payload[6]
+            elif len(payload) >= 2:
+                pct_byte = payload[1] & 0xFF
+                if pct_byte not in (0xE0,):
+                    result["oil_remaining"] = int(pct_byte / 2.55)
+        elif dp_id == SM_GW_DP_LIGHT and len(payload) >= 2:
+            light_type = payload[0] & 0xFF
+            light_status = payload[1] & 0xFF
+            if light_type == 1:
+                result["light_on"] = light_status == 1
+            elif light_type in (3, 7):
+                result["light_on"] = light_status in (1, 2)
+            else:
+                result["light_on"] = False
+        elif dp_id == SM_GW_DP_PASSWORD and len(payload) >= 1:
+            result["password_required"] = payload[0] != SM_GW_PASSWORD_OK_BYTE
+        elif dp_id == SM_GW_DP_FAN and len(payload) >= 3:
+            # [size, max_level, current_level] — surface current_level only.
+            result["fan"] = (payload[2] & 0xFF) > 0
+
+    def _parse_dp(self, frame: bytes, idx: int, dp_id: int, result: dict) -> int:
+        """Parse a single DP starting at `idx`. Returns the new index."""
+        if dp_id == SM_GW_DP_POWER:
+            result["power"] = (frame[idx + 1] & 0xFF) == 1
+            result["phase"] = "idle" if result["power"] else "off"
+            return idx + 2
+
+        if dp_id == SM_GW_DP_LOCK:
+            result["lock"] = frame[idx + 1] == 1
+            return idx + 2
+
+        # All remaining DPs we care about are composite (AF/BF-tagged)
+        # with a 2-byte big-endian length prefix.
+        type_tag = frame[idx]
+        if type_tag not in (SM_GW_TYPE_BINARY, SM_GW_TYPE_TEXT):
+            # Unknown / inline DP — bail out, the rest of the frame is
+            # likely misaligned anyway.
+            return len(frame)
+
+        length = (frame[idx + 1] << 8) | frame[idx + 2]
+        payload_start = idx + 3
+        payload = frame[payload_start:payload_start + length]
+        self._dispatch_composite(dp_id, type_tag, payload, result)
+        return payload_start + length
+
+
+class ScentMarketingGwXorProtocol(ScentMarketingGwProtocol):
+    """Scent Marketing — GW family with XOR-encrypted JSON payloads.
+
+    Used by WiFi (mfr-data leading byte 01/02/03) and Cellular (B1/B2)
+    variants. The transport layer is identical to plain GW (multi-packet
+    chunking on EE01/EE02/EE03), but the inner payload is JSON encrypted
+    with a 256-byte lookup-table stream cipher keyed by the MAC address.
+    """
+
+    device_type = DeviceType.SCENT_MARKETING_GW_XOR
+
+    def __init__(self, mac: str = "", tuya_dp_mode: bool = False) -> None:
+        super().__init__(tuya_dp_mode=tuya_dp_mode)
+        # MAC is needed for the encryption key. Some flows learn it only
+        # after the first advertisement is observed, so we allow updates.
+        self._mac = mac.upper().replace(":", "")
+
+    def set_mac(self, mac: str) -> None:
+        self._mac = mac.upper().replace(":", "")
+
+    # ------------------------------------------------------------------
+    # XOR stream cipher (HexConver.dataEncrypt / dataDecrypt)
+    # ------------------------------------------------------------------
+
+    def _xor_keystream_start(self, nonce: int) -> int:
+        if len(self._mac) < 10:
+            raise ValueError("XOR protocol requires a 12-hex-char MAC")
+        return int(self._mac[8:10], 16) ^ (nonce & 0xFF)
+
+    def encrypt(self, plaintext: bytes) -> bytes:
+        """Encrypt a JSON payload. The first byte of the result is the nonce."""
+        nonce = random.randint(0, len(SM_GW_XOR_DICT) - 1)
+        out = bytearray(len(plaintext) + 1)
+        out[0] = nonce
+        idx = self._xor_keystream_start(nonce)
+        for i, b in enumerate(plaintext):
+            out[i + 1] = SM_GW_XOR_DICT[idx & 0xFF] ^ b
+            idx += 1
+        return bytes(out)
+
+    def decrypt(self, ciphertext: bytes) -> bytes:
+        if len(ciphertext) < 2:
+            return b""
+        nonce = ciphertext[0]
+        idx = self._xor_keystream_start(nonce)
+        out = bytearray(len(ciphertext) - 1)
+        for i in range(1, len(ciphertext)):
+            out[i - 1] = SM_GW_XOR_DICT[idx & 0xFF] ^ ciphertext[i]
+            idx += 1
+        return bytes(out)
+
+    # ------------------------------------------------------------------
+    # Commands
+    # ------------------------------------------------------------------
+    # WiFi-flagged GW devices receive the same DP frame as plain BLE
+    # devices, just wrapped in an outer `{"time": <unix>, "data": {<dps>}}`
+    # JSON and then run through the XOR stream cipher. We reuse the parent
+    # class's binary frame builders and translate them into the JSON
+    # representation Mirrors of `IOTDataParse.writeDeviceProperty()` use.
+
+    @staticmethod
+    def _wrap_for_wire(dp_json: dict) -> bytes:
+        wrapped = {"time": int(time.time()), "data": dp_json}
+        return json.dumps(wrapped, separators=(",", ":")).encode("utf-8")
+
+    @staticmethod
+    def _dp_to_json(dp_id: int, value: int | str, type_int: int) -> dict:
+        return {str(dp_id): {"type": type_int, "value": value}}
+
+    def build_power(self, on: bool) -> bytes:
+        dp_json = self._dp_to_json(SM_GW_DP_POWER, 1 if on else 0, SM_GW_TYPE_BOOL)
+        return self.encrypt(self._wrap_for_wire(dp_json))
+
+    def build_lock(self, on: bool) -> bytes:
+        dp_json = self._dp_to_json(SM_GW_DP_LOCK, 1 if on else 0, SM_GW_TYPE_LOCK)
+        return self.encrypt(self._wrap_for_wire(dp_json))
+
+    def build_query(self) -> bytes:
+        # The device emits state automatically; an explicit query is not
+        # part of the WiFi-XOR protocol. We still send something to nudge
+        # the firmware (the plaintext init packet) — encrypted, so the
+        # device's input pipeline accepts it.
+        return self.encrypt(b'{"query":1}')
+
+    # ------------------------------------------------------------------
+    # Notification parsing
+    # ------------------------------------------------------------------
+
+    def parse_notification(self, data: bytes) -> dict:
+        frame = self.handle_transport_chunk(data)
+        if frame is None:
+            return {}
+        try:
+            plaintext = self.decrypt(frame)
+            obj = json.loads(plaintext.decode("utf-8", errors="replace"))
+        except Exception as err:
+            _LOGGER.debug("Scent Marketing GW-XOR: decrypt/parse failed: %s", err)
+            return {}
+        return self._map_json_state(obj)
+
+    @staticmethod
+    def _map_json_state(obj: dict) -> dict:
+        """Translate the device's JSON state into our DiffuserState fields.
+
+        Accepts both the `{<dp_id>: {"type": ..., "value": ...}}` flat form
+        and the `{"time": ..., "data": {...}}` wrapped form the Android
+        app uses on the write path.
+        """
+        if not isinstance(obj, dict):
+            return {}
+        if "data" in obj and isinstance(obj["data"], dict):
+            obj = obj["data"]
+        result: dict = {}
+        for raw_key, raw_val in obj.items():
+            try:
+                dp_id = int(raw_key)
+            except (TypeError, ValueError):
+                continue
+            value = raw_val
+            if isinstance(raw_val, dict):
+                value = raw_val.get("value", raw_val)
+            if dp_id == SM_GW_DP_POWER:
+                result["power"] = bool(int(value)) if value not in (None, "") else False
+                result["phase"] = "idle" if result["power"] else "off"
+            elif dp_id == SM_GW_DP_LOCK:
+                result["lock"] = bool(int(value)) if value not in (None, "") else False
+            elif dp_id == SM_GW_DP_BATTERY:
+                try:
+                    result["battery"] = int(value, 16) if isinstance(value, str) else int(value)
+                except (TypeError, ValueError):
+                    pass
+            elif dp_id == SM_GW_DP_NAME and isinstance(value, str):
+                # Tuya-style BF values arrive as hex strings; try to decode.
+                try:
+                    decoded = bytes.fromhex(value).rstrip(b"\x00").decode("utf-8", errors="replace")
+                    if decoded:
+                        result["device_name"] = decoded.strip()
+                except ValueError:
+                    result["device_name"] = value
+        return result
+
+
+# ---------------------------------------------------------------------------
 # Factory
 # ---------------------------------------------------------------------------
 
-def get_protocol(device_type: DeviceType) -> BleProtocol:
-    """Get the appropriate protocol handler for a device type."""
+def get_protocol(
+    device_type: DeviceType,
+    mac: str = "",
+    pid: int | None = None,
+) -> BleProtocol:
+    """Get the appropriate protocol handler for a device type.
+
+    For Scent Marketing GW devices a PID of 98 selects the Tuya-DP hex
+    parser instead of the regular binary one.
+    """
+    tuya = (pid == 98)
     if device_type == DeviceType.TUYA_BLE:
         return TuyaBleProtocol()
     elif device_type == DeviceType.AROMA_LINK:
         return AromaLinkBleProtocol()
     elif device_type == DeviceType.SCENTIMENT:
         return ScentimentProtocol()
+    elif device_type == DeviceType.SCENT_MARKETING_AK:
+        return ScentMarketingAkProtocol()
+    elif device_type == DeviceType.SCENT_MARKETING_GW:
+        return ScentMarketingGwProtocol(tuya_dp_mode=tuya)
+    elif device_type == DeviceType.SCENT_MARKETING_GW_XOR:
+        return ScentMarketingGwXorProtocol(mac=mac, tuya_dp_mode=tuya)
     raise ValueError(f"Unknown device type: {device_type}")
 
 
-def detect_device_type(ble_name: str) -> DeviceType | None:
-    """Detect device type from BLE advertisement name (case-insensitive)."""
+def _detect_scent_marketing(advertisement_data) -> DeviceType | None:
+    """Match Scent Marketing manufacturer-specific data.
+
+    Mirrors `DeviceModel.deviceFiltration` in the decompiled app: the
+    manufacturer ID picks the family, and (for GW devices) the first byte
+    of the manufacturer payload distinguishes plain BLE from the WiFi /
+    Cellular XOR-encrypted variants.
+    """
+    if advertisement_data is None:
+        return None
+    mfr_data = getattr(advertisement_data, "manufacturer_data", None)
+    if not mfr_data:
+        return None
+
+    if SM_MFR_ID_AK in mfr_data:
+        return DeviceType.SCENT_MARKETING_AK
+
+    gw_payload = mfr_data.get(SM_MFR_ID_GW) or mfr_data.get(SM_MFR_ID_GW_ALT)
+    if gw_payload is None:
+        return None
+
+    lead = gw_payload[:1].hex().upper() if gw_payload else ""
+    if lead in SM_GW_FLAG_WIFI or lead in SM_GW_FLAG_CELLULAR:
+        return DeviceType.SCENT_MARKETING_GW_XOR
+    return DeviceType.SCENT_MARKETING_GW
+
+
+def extract_scent_marketing_metadata(advertisement_data) -> dict:
+    """Return diagnostic fields from a Scent Marketing advertisement.
+
+    Used by the config flow + diagnostics exporter so the reporter's logs
+    contain everything we need to validate/debug detection without having
+    to ask for raw advertisement dumps separately.
+    """
+    out: dict = {"mfr_id": None, "raw_hex": "", "pid": None, "wifi_flag": None,
+                 "heartbeat": False, "mac_from_adv": None}
+    if advertisement_data is None:
+        return out
+    mfr_data = getattr(advertisement_data, "manufacturer_data", None) or {}
+    for mfr_id in (SM_MFR_ID_AK, SM_MFR_ID_GW, SM_MFR_ID_GW_ALT):
+        if mfr_id in mfr_data:
+            payload = mfr_data[mfr_id]
+            out["mfr_id"] = mfr_id
+            out["raw_hex"] = payload.hex().upper()
+            hex_str = out["raw_hex"]
+            if mfr_id == SM_MFR_ID_AK:
+                if hex_str[:2] == SM_AK_FLAG_HEARTBEAT:
+                    out["heartbeat"] = True
+                if len(hex_str) > 22:
+                    out["mac_from_adv"] = hex_str[10:22]
+            else:  # GW
+                lead = hex_str[:2]
+                if lead in SM_GW_FLAG_WIFI:
+                    out["wifi_flag"] = "wifi"
+                elif lead in SM_GW_FLAG_CELLULAR:
+                    out["wifi_flag"] = "cellular"
+                else:
+                    out["wifi_flag"] = "ble"
+                if len(hex_str) > 5:
+                    try:
+                        out["pid"] = int(hex_str[2:6], 16)
+                    except ValueError:
+                        pass
+                if len(hex_str) > 33:
+                    out["mac_from_adv"] = hex_str[22:34]
+            break
+    return out
+
+
+def detect_device_type(
+    ble_name: str,
+    advertisement_data=None,
+) -> DeviceType | None:
+    """Detect device type from advertisement.
+
+    Detection priority:
+      1. Manufacturer-specific data for Scent Marketing families (most
+         reliable — the Android app uses this exclusively).
+      2. BLE local-name prefix patterns for the other families.
+    """
+    sm_type = _detect_scent_marketing(advertisement_data)
+    if sm_type is not None:
+        return sm_type
+
     if not ble_name:
         return None
     lowered = ble_name.lower()
-    for dtype, patterns in {
-        DeviceType.AROMA_LINK: ["Scent "],
-        DeviceType.TUYA_BLE: ["BT-ivy"],
-        DeviceType.SCENTIMENT: ["Scentiment"],
-    }.items():
+    for dtype, patterns in BLE_NAME_PATTERNS.items():
         for pattern in patterns:
             if lowered.startswith(pattern.lower()):
                 return dtype

--- a/custom_components/scent_assistant/sensor.py
+++ b/custom_components/scent_assistant/sensor.py
@@ -9,7 +9,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import PERCENTAGE
+from homeassistant.const import PERCENTAGE, EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -17,6 +17,13 @@ from .const import DOMAIN, DeviceType
 from .device import ScentDiffuserDevice
 
 _LOGGER = logging.getLogger(__name__)
+
+SCENT_MARKETING_TYPES = {
+    DeviceType.SCENT_MARKETING_AK,
+    DeviceType.SCENT_MARKETING_GW,
+    DeviceType.SCENT_MARKETING_GW_XOR,
+}
+GW_TYPES = {DeviceType.SCENT_MARKETING_GW, DeviceType.SCENT_MARKETING_GW_XOR}
 
 
 async def async_setup_entry(
@@ -34,6 +41,13 @@ async def async_setup_entry(
     if device.device_type == DeviceType.SCENTIMENT:
         entities.append(DiffuserBatterySensor(device, entry))
 
+    if device.device_type in GW_TYPES:
+        entities.append(DiffuserBatterySensor(device, entry))
+        entities.append(DiffuserOilSensor(device, entry))
+
+    if device.device_type in SCENT_MARKETING_TYPES:
+        entities.append(DiffuserDetectionDiagnostic(device, entry))
+
     async_add_entities(entities)
 
 
@@ -47,9 +61,7 @@ class DiffuserStatusSensor(SensorEntity):
     def __init__(self, device: ScentDiffuserDevice, entry: ConfigEntry) -> None:
         self._device = device
         self._attr_unique_id = f"{device.unique_id}_status"
-        self._attr_device_info = {
-            "identifiers": {(DOMAIN, device.unique_id)},
-        }
+        self._attr_device_info = device.device_info
         device.register_state_callback(self._on_state_update)
 
     def _on_state_update(self) -> None:
@@ -90,9 +102,7 @@ class DiffuserBatterySensor(SensorEntity):
     def __init__(self, device: ScentDiffuserDevice, entry: ConfigEntry) -> None:
         self._device = device
         self._attr_unique_id = f"{device.unique_id}_battery"
-        self._attr_device_info = {
-            "identifiers": {(DOMAIN, device.unique_id)},
-        }
+        self._attr_device_info = device.device_info
         device.register_state_callback(self._on_state_update)
 
     def _on_state_update(self) -> None:
@@ -109,6 +119,74 @@ class DiffuserBatterySensor(SensorEntity):
         return self._device.available and self._device.state.battery is not None
 
 
+class DiffuserOilSensor(SensorEntity):
+    """Remaining fragrance oil percentage (Scent Marketing GW family)."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Oil remaining"
+    _attr_icon = "mdi:water-percent"
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_native_unit_of_measurement = PERCENTAGE
+
+    def __init__(self, device: ScentDiffuserDevice, entry: ConfigEntry) -> None:
+        self._device = device
+        self._attr_unique_id = f"{device.unique_id}_oil"
+        self._attr_device_info = device.device_info
+        device.register_state_callback(self._on_state_update)
+
+    def _on_state_update(self) -> None:
+        if self.hass is None:
+            return
+        self.async_write_ha_state()
+
+    @property
+    def native_value(self) -> int | None:
+        return self._device.state.oil_remaining
+
+    @property
+    def available(self) -> bool:
+        return self._device.available and self._device.state.oil_remaining is not None
+
+
+class DiffuserDetectionDiagnostic(SensorEntity):
+    """Exposes Scent Marketing detection metadata as a diagnostic entity.
+
+    The state is the detected protocol family; attributes carry the raw
+    advertisement bytes plus the manufacturer ID, PID and WiFi flag. This
+    is what a non-technical reporter screenshots when something doesn't
+    work — no need to dig through HA's text logs.
+    """
+
+    _attr_has_entity_name = True
+    _attr_name = "Detected family"
+    _attr_icon = "mdi:bluetooth-settings"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, device: ScentDiffuserDevice, entry: ConfigEntry) -> None:
+        self._device = device
+        self._attr_unique_id = f"{device.unique_id}_sm_detection"
+        self._attr_device_info = device.device_info
+
+    @property
+    def native_value(self) -> str:
+        return self._device.device_type.value
+
+    @property
+    def extra_state_attributes(self) -> dict:
+        meta = self._device.sm_metadata or {}
+        return {
+            "manufacturer_id": meta.get("mfr_id"),
+            "pid": meta.get("pid"),
+            "wifi_flag": meta.get("wifi_flag"),
+            "heartbeat": meta.get("heartbeat"),
+            "mac_from_advertisement": meta.get("mac_from_adv"),
+            "raw_advertisement_hex": meta.get("raw_hex"),
+            "model": self._device.model_name,
+            "firmware_version": self._device.state.firmware_version,
+            "password_required": self._device.state.password_required,
+        }
+
+
 class DiffuserConnectionSensor(SensorEntity):
     """Shows the current connection mode (BLE/Cloud/Offline)."""
 
@@ -120,9 +198,7 @@ class DiffuserConnectionSensor(SensorEntity):
     def __init__(self, device: ScentDiffuserDevice, entry: ConfigEntry) -> None:
         self._device = device
         self._attr_unique_id = f"{device.unique_id}_connection"
-        self._attr_device_info = {
-            "identifiers": {(DOMAIN, device.unique_id)},
-        }
+        self._attr_device_info = device.device_info
         device.register_state_callback(self._on_state_update)
 
     def _on_state_update(self) -> None:

--- a/custom_components/scent_assistant/strings.json
+++ b/custom_components/scent_assistant/strings.json
@@ -30,6 +30,13 @@
         "data": {
           "cloud_device_id": "Device"
         }
+      },
+      "gw_password": {
+        "title": "Scent Marketing — Device Password (optional)",
+        "description": "If your Scent Marketing GW device requires a 4-character password (set previously in the manufacturer's app), enter it here. Leave blank if the device is unprotected.",
+        "data": {
+          "gw_password": "Device password (4 ASCII characters, optional)"
+        }
       }
     },
     "error": {

--- a/custom_components/scent_assistant/switch.py
+++ b/custom_components/scent_assistant/switch.py
@@ -8,10 +8,16 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
+from .const import DOMAIN, DeviceType
 from .device import ScentDiffuserDevice
 
 _LOGGER = logging.getLogger(__name__)
+
+SCENT_MARKETING_TYPES = {
+    DeviceType.SCENT_MARKETING_AK,
+    DeviceType.SCENT_MARKETING_GW,
+    DeviceType.SCENT_MARKETING_GW_XOR,
+}
 
 
 async def async_setup_entry(
@@ -28,6 +34,15 @@ async def async_setup_entry(
     if device.supports_fan and not is_cloud:
         entities.append(DiffuserFanSwitch(device, entry))
 
+    # Scent Marketing devices expose extra controls when running on BLE.
+    if device.device_type in SCENT_MARKETING_TYPES and not is_cloud:
+        entities.append(DiffuserLockSwitch(device, entry))
+        if device.device_type == DeviceType.SCENT_MARKETING_AK:
+            # The AK control bitmask carries lamp + fan bits we can drive
+            # without any extra protocol work.
+            entities.append(DiffuserLampSwitch(device, entry))
+            entities.append(DiffuserFanSwitch(device, entry))
+
     async_add_entities(entities)
 
 
@@ -41,12 +56,7 @@ class DiffuserPowerSwitch(SwitchEntity):
     def __init__(self, device: ScentDiffuserDevice, entry: ConfigEntry) -> None:
         self._device = device
         self._attr_unique_id = f"{device.unique_id}_power"
-        self._attr_device_info = {
-            "identifiers": {(DOMAIN, device.unique_id)},
-            "name": device.name,
-            "manufacturer": "Scent Diffuser",
-            "model": device.device_type.value,
-        }
+        self._attr_device_info = device.device_info
         device.register_state_callback(self._on_state_update)
 
     def _on_state_update(self) -> None:
@@ -67,6 +77,68 @@ class DiffuserPowerSwitch(SwitchEntity):
         await self._device.set_power(False)
 
 
+class DiffuserLockSwitch(SwitchEntity):
+    """Child-lock switch (Scent Marketing devices)."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Child lock"
+    _attr_icon = "mdi:lock"
+
+    def __init__(self, device: ScentDiffuserDevice, entry: ConfigEntry) -> None:
+        self._device = device
+        self._attr_unique_id = f"{device.unique_id}_lock"
+        self._attr_device_info = device.device_info
+        device.register_state_callback(self._on_state_update)
+
+    def _on_state_update(self) -> None:
+        self.async_write_ha_state()
+
+    @property
+    def is_on(self) -> bool | None:
+        return self._device.state.lock
+
+    @property
+    def available(self) -> bool:
+        return self._device.available
+
+    async def async_turn_on(self, **kwargs) -> None:
+        await self._device.set_lock(True)
+
+    async def async_turn_off(self, **kwargs) -> None:
+        await self._device.set_lock(False)
+
+
+class DiffuserLampSwitch(SwitchEntity):
+    """Auxiliary LED / lamp switch (Scent Marketing AK family)."""
+
+    _attr_has_entity_name = True
+    _attr_name = "Lamp"
+    _attr_icon = "mdi:lightbulb"
+
+    def __init__(self, device: ScentDiffuserDevice, entry: ConfigEntry) -> None:
+        self._device = device
+        self._attr_unique_id = f"{device.unique_id}_lamp"
+        self._attr_device_info = device.device_info
+        device.register_state_callback(self._on_state_update)
+
+    def _on_state_update(self) -> None:
+        self.async_write_ha_state()
+
+    @property
+    def is_on(self) -> bool | None:
+        return self._device.state.light_on
+
+    @property
+    def available(self) -> bool:
+        return self._device.available
+
+    async def async_turn_on(self, **kwargs) -> None:
+        await self._device.set_lamp(True)
+
+    async def async_turn_off(self, **kwargs) -> None:
+        await self._device.set_lamp(False)
+
+
 class DiffuserFanSwitch(SwitchEntity):
     """Fan on/off switch (Aroma-Link only, requires Bluetooth)."""
 
@@ -78,9 +150,7 @@ class DiffuserFanSwitch(SwitchEntity):
         self._device = device
         self._is_cloud_only = entry.data.get("connection_mode") == "cloud"
         self._attr_unique_id = f"{device.unique_id}_fan"
-        self._attr_device_info = {
-            "identifiers": {(DOMAIN, device.unique_id)},
-        }
+        self._attr_device_info = device.device_info
         device.register_state_callback(self._on_state_update)
 
     def _on_state_update(self) -> None:


### PR DESCRIPTION
## Summary
- Implements all three Scent Marketing app protocol families (AK + GW + GW-XOR) plus the Tuya-DP variant for PID 98
- Detection routes by BLE manufacturer-specific data (0x5943 / 0x460C / 0xF001), mirroring the manufacturer's Android app
- Adds child-lock, lamp, fan, oil-remaining and battery entities for the new families; surfaces the detected family on the device page and via a downloadable diagnostics JSON for easy bug reports
- Bumps version to `1.2.0-beta.1` — beta release awaiting hardware validation against issue #8

## Test plan
- [x] Smoke tests: detection across all families, builder/parser round-trips for power, lock, password, name, remark, light, wind, time-sync, schedule (AK v2 + GW handleTasksAndPower)
- [x] Tuya-DP parser handles bool / int / AF / BF DPs in a single frame
- [x] GW-XOR round-trip: encrypt → decrypt produces identical bytes; build_power wraps as `{"time": ..., "data": {...}}`
- [x] Multi-packet transport: 18-byte chunks with (nonce, seq) header + terminator chunk for 18-byte-aligned frames
- [x] All integration files compile cleanly
- [ ] Validate against real `SA_Home Scent` hardware (@angeldero, issue #8)