### PR TITLE
feat: detect DAP / AromaPlan diffusers as Aroma-Link variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@
 | Aroma-Link WiFi+BLE Diffusers | Aroma-Link | BLE + Cloud | Full support including fan control via BLE |
 | JCloud Scent Diffusers | Aroma-Link | BLE + Cloud | Same as Aroma-Link, different branding |
 | Cavir Smart Scent Air Machine | Aroma-Link | BLE + Cloud | Same as Aroma-Link, different branding |
-| AromaPlan Diffusers | Aroma-Link | BLE + Cloud | Same as Aroma-Link, different branding |
+| AromaPlan Diffusers | AromaPlan | BLE + Cloud | Same as Aroma-Link, different branding |
+| DAP Smart Scent Air Machine (Model 11, A5) | AromaPlan | BLE | Broadcasts as `DAP.A5.Bluetooth`; uses Aroma-Link protocol |
 | Crearoma Diffusers | Aroma-Link | BLE + Cloud | Same as Aroma-Link, different branding |
 | ShinePick QT-I300 | Aroma Buddy | BLE | Tuya BLE protocol |
 | Scentiment Diffuser Air 2 | Scentiment | BLE | JSON-over-BLE protocol; intensity, RGB LED, battery |

--- a/custom_components/scent_assistant/const.py
+++ b/custom_components/scent_assistant/const.py
@@ -118,7 +118,9 @@ SM_GW_ALT_WRITE_UUID = "0000ff03-0000-1000-8000-00805f9b34fb"
 # ---------------------------------------------------------------------------
 
 BLE_NAME_PATTERNS = {
-    DeviceType.AROMA_LINK: ["Scent "],
+    # "Scent " — Aroma-Link / JCloud / Cavir / Crearoma (Dewoo OEM, Aroma-Link app)
+    # "DAP.A5" — DAP Smart Scent Air Machine (Dewoo OEM, AromaPlan app)
+    DeviceType.AROMA_LINK: ["Scent ", "DAP.A5"],
     DeviceType.TUYA_BLE: ["BT-ivy"],
     DeviceType.SCENTIMENT: ["Scentiment"],
 }


### PR DESCRIPTION
## Summary

Adds `"DAP.A5"` to the AROMA_LINK BLE name-pattern list so DAP Smart Scent Air Machine devices (sold under the AromaPlan app brand) are auto-detected by the config flow. README already lists "AromaPlan Diffusers" under **Confirmed Working**, so this fix closes the gap between the documented support and what the detector actually matches. Adds a separate README row for the DAP hardware to make the broadcast-name distinction discoverable.

One-line code change in `custom_components/scent_assistant/const.py`. No protocol changes — DAP devices use the existing Aroma-Link control path unmodified.

## Why this works

DAP, AromaPlan, Aroma-Link, and Aroma Designers are all apps published by **Dewoo** (Chinese OEM):

- [Aroma-Link](https://play.google.com/store/apps/details?id=com.dewoo.lot.android.prod) — `com.dewoo.lot.android.prod`
- [AromaPlan](https://play.google.com/store/apps/details?id=com.dewoo.lot.aromaplan) — `com.dewoo.lot.aromaplan`
- [Aroma Designers](https://play.google.com/store/apps/details?id=com.dewoo.lot.aromadesigner.prod) — `com.dewoo.lot.aromadesigner.prod`

All four apps drive the same underlying BLE protocol:

- Service UUID: `0000fff0-0000-1000-8000-00805f9b34fb`
- Write characteristic: `0000fff2-…`
- Notify characteristic: `0000fff1-…`

…which is exactly what `DeviceType.AROMA_LINK` already implements in this integration. The only thing missing was a name pattern that would match DAP's BLE advertisement.

## Hardware tested

- **Device:** DAP Smart Scent Air Machine, Model 11
- **App brand:** AromaPlan
- **BLE advertising name observed:** `DAP.A5.Bluetooth`

After applying this patch to a live HA install, the device paired via the standard config flow and the following entities materialized — all driven by the existing Aroma-Link code path with no further changes:

- `switch.*_power`
- `switch.*_fan`
- `sensor.*_status`
- `number.*_work_duration`
- `number.*_pause_duration`
- `time.*_start_time`
- `time.*_end_time`
- `button.*_sync_time`

## Changes

- `custom_components/scent_assistant/const.py` — add `"DAP.A5"` to the AROMA_LINK pattern list, with an inline comment naming both Dewoo OEM branches.
- `README.md` — add a row for the DAP hardware under Confirmed Working, and correct the App column for the existing AromaPlan row from "Aroma-Link" to "AromaPlan" (the device is sold with the AromaPlan app, not the Aroma-Link app, even though the underlying protocol is identical).

## Notes

- No new dependencies.
- No protocol or behavioral changes for any existing device.
- No test infrastructure currently in the repo, so no tests added.
